### PR TITLE
ci: Update Github Actions cache keys ot consider version catalog toml file

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -80,6 +80,20 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.OS }}-gradle-wrapper-cache-
+      - name: Cache Gradle caches
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
+          restore-keys: |
+            ${{ runner.OS }}-gradle-caches-cache-
       - name: generate ksProp file
         run: ./gradlew generateKsPropFile
       - name: generate google-services.json file

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,12 +2,16 @@ name: Android CI
 
 on: [ push ]
 
+env:
+  GRADLE_WRAPPER_CACHE_KEY: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
+  GRADLE_CACHES_CACHE_KEY: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
+
 jobs:
 
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: '3.1'
@@ -21,14 +25,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
-          key: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
+          key: ${{ env.GRADLE_WRAPPER_CACHE_KEY }}
           restore-keys: |
             ${{ runner.OS }}-gradle-wrapper-cache-
       - name: Cache Gradle caches
         uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
+          key: ${{ env.GRADLE_CACHES_CACHE_KEY }}
           restore-keys: |
             ${{ runner.OS }}-gradle-caches-cache-
       - name: generate ksProp file
@@ -50,12 +54,26 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
+      - name: Cache Gradle wrapper
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/wrapper
+          key: ${{ env.GRADLE_WRAPPER_CACHE_KEY }}
+          restore-keys: |
+            ${{ runner.OS }}-gradle-wrapper-cache-
+      - name: Cache Gradle caches
+        uses: actions/cache@v3
+        with:
+          path: ~/.gradle/caches
+          key: ${{ env.GRADLE_CACHES_CACHE_KEY }}
+          restore-keys: |
+            ${{ runner.OS }}-gradle-caches-cache-
       - name: generate ksProp file
         run: ./gradlew generateKsPropFile
       - name: generate google-services.json file
@@ -74,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -84,14 +102,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
-          key: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
+          key: ${{ env.GRADLE_WRAPPER_CACHE_KEY }}
           restore-keys: |
             ${{ runner.OS }}-gradle-wrapper-cache-
       - name: Cache Gradle caches
         uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
+          key: ${{ env.GRADLE_CACHES_CACHE_KEY }}
           restore-keys: |
             ${{ runner.OS }}-gradle-caches-cache-
       - name: generate ksProp file

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -134,6 +134,12 @@ jobs:
         with:
           name: ui-test-video
           path: ./ui-test.mp4
+      - name: Upload UI test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-results
+          path: app/build/reports/androidTests/connected/
 
   notify-slack:
     needs: unit-test

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,14 +21,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
-          key: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
+          key: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.OS }}-gradle-wrapper-cache-
       - name: Cache Gradle caches
         uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
-          key: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts') }}
+          key: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.OS }}-gradle-caches-cache-
       - name: generate ksProp file

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,10 +2,6 @@ name: Android CI
 
 on: [ push ]
 
-env:
-  GRADLE_WRAPPER_CACHE_KEY: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
-  GRADLE_CACHES_CACHE_KEY: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
-
 jobs:
 
   unit-test:
@@ -25,14 +21,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
-          key: ${{ env.GRADLE_WRAPPER_CACHE_KEY }}
+          key: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.OS }}-gradle-wrapper-cache-
       - name: Cache Gradle caches
         uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
-          key: ${{ env.GRADLE_CACHES_CACHE_KEY }}
+          key: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.OS }}-gradle-caches-cache-
       - name: generate ksProp file
@@ -64,14 +60,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
-          key: ${{ env.GRADLE_WRAPPER_CACHE_KEY }}
+          key: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.OS }}-gradle-wrapper-cache-
       - name: Cache Gradle caches
         uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
-          key: ${{ env.GRADLE_CACHES_CACHE_KEY }}
+          key: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.OS }}-gradle-caches-cache-
       - name: generate ksProp file
@@ -102,14 +98,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.gradle/wrapper
-          key: ${{ env.GRADLE_WRAPPER_CACHE_KEY }}
+          key: ${{ runner.OS }}-gradle-wrapper-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/wrapper/gradle-wrapper.properties', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.OS }}-gradle-wrapper-cache-
       - name: Cache Gradle caches
         uses: actions/cache@v3
         with:
           path: ~/.gradle/caches
-          key: ${{ env.GRADLE_CACHES_CACHE_KEY }}
+          key: ${{ runner.OS }}-gradle-caches-cache-${{ hashFiles('build.gradle.kts', 'settings.gradle.kts', 'gradle/libs.versions.toml') }}
           restore-keys: |
             ${{ runner.OS }}-gradle-caches-cache-
       - name: generate ksProp file


### PR DESCRIPTION
- Update Github Actions cache keys to consider changes in version catalog toml file for resetting the cache
- Add caching for the lint job as well
- Use env vars for reusing the cache keys between the jobs