### PR TITLE
DROID-19: Add copy to clipboard feature

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -120,7 +120,8 @@ tasks.register<JacocoReport>("jacocoTestReport") {
     )
     val kotlinDebugTree = fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) { exclude(fileFilter) }
     val mainKotlinSrc = layout.projectDirectory.dir("src/main/kotlin")
-    sourceDirectories.from(files(mainKotlinSrc))
+    val mainJavaSrc = layout.projectDirectory.dir("src/main/java")
+    sourceDirectories.from(files(mainKotlinSrc, mainJavaSrc))
     classDirectories.from(files(kotlinDebugTree))
     executionData.from(fileTree(layout.buildDirectory) {
         include(

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/MainActivityAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/MainActivityAndroidTest.kt
@@ -41,7 +41,7 @@ internal class MainActivityAndroidTest {
         // arrange
         // act
         // assert
-        onView(withId(R.id.tvOutput)).check(matches(isDisplayed()))
+        onView(withId(R.id.composeOutput)).check(matches(isDisplayed()))
         onView(withId(R.id.btEnter)).check(matches(isDisplayed()))
         onView(withId(R.id.etInput)).check(matches(isDisplayed()))
     }

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
@@ -1,0 +1,77 @@
+package org.kabiri.android.usbterminal.ui.terminal
+
+import android.content.ClipboardManager
+import android.content.Context
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.longClick
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performTouchInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.kabiri.android.usbterminal.model.OutputText
+import org.kabiri.android.usbterminal.ui.theme.UsbTerminalTheme
+
+@RunWith(AndroidJUnit4::class)
+class TerminalOutputAndroidTest {
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun terminalOutput_displaysAllLines() {
+        // arrange
+        val logs =
+            mutableStateListOf(
+                OutputText("Line 1", OutputText.OutputType.TYPE_NORMAL),
+                OutputText("Error!", OutputText.OutputType.TYPE_ERROR),
+                OutputText("Info", OutputText.OutputType.TYPE_INFO),
+            )
+
+        // act
+        composeRule.setContent {
+            UsbTerminalTheme {
+                TerminalOutput(logs = logs, autoScroll = false)
+            }
+        }
+
+        // assert
+        composeRule.onNodeWithText("Line 1").assertIsDisplayed()
+        composeRule.onNodeWithText("Error!").assertIsDisplayed()
+        composeRule.onNodeWithText("Info").assertIsDisplayed()
+    }
+
+    @Test
+    fun terminalOutput_longPressCopiesAllText() {
+        // arrange
+        val context = composeRule.activity
+        val logs =
+            mutableStateListOf(
+                OutputText("A\n", OutputText.OutputType.TYPE_NORMAL),
+                OutputText("B", OutputText.OutputType.TYPE_NORMAL),
+            )
+
+        composeRule.setContent {
+            UsbTerminalTheme {
+                TerminalOutput(logs = logs, autoScroll = false)
+            }
+        }
+
+        // act: long-press on one of the visible lines (parent handles the gesture)
+        composeRule.onNodeWithText("B").performTouchInput { longClick() }
+        composeRule.waitForIdle()
+
+        // assert clipboard contains concatenated text
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val copied =
+            clipboard.primaryClip
+                ?.getItemAt(0)
+                ?.coerceToText(context)
+                ?.toString()
+        assertThat(copied).isEqualTo("A\nB")
+    }
+}

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
@@ -57,7 +57,7 @@ class TerminalOutputAndroidTest {
 
         composeRule.setContent {
             UsbTerminalTheme {
-                TerminalOutput(logs = logs, autoScroll = false)
+                TerminalOutput(logs = logs, autoScroll = true)
             }
         }
 

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag
@@ -149,8 +150,8 @@ class TerminalOutputAndroidTest {
             }
         }
 
-        // assert: composable exists even with empty logs and autoScroll enabled
-        composeRule.onNodeWithTag("terminal").assertExists().assertIsDisplayed()
+        // assert: composable exists but not enabled when with empty logs and autoScroll enabled
+        composeRule.onNodeWithTag("terminal").assertExists()
     }
 
     @Test

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
@@ -4,6 +4,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -91,9 +92,7 @@ class TerminalOutputAndroidTest {
                 TerminalOutput(
                     logs = logs,
                     autoScroll = false,
-                    modifier =
-                        androidx.compose.ui.Modifier
-                            .testTag("terminal"),
+                    modifier = Modifier.testTag("terminal"),
                 )
             }
         }
@@ -115,8 +114,7 @@ class TerminalOutputAndroidTest {
                     logs = logs,
                     autoScroll = false,
                     modifier =
-                        androidx.compose.ui.Modifier
-                            .testTag("terminal"),
+                        Modifier.testTag("terminal"),
                 )
             }
         }
@@ -133,5 +131,53 @@ class TerminalOutputAndroidTest {
                 ?.coerceToText(context)
                 ?.toString()
         assertThat(copied).isEqualTo("")
+    }
+
+    @Test
+    fun terminalOutput_autoScrollTrue_withEmptyList_isStable() {
+        // arrange
+        val logs = mutableStateListOf<OutputText>()
+
+        // act
+        composeRule.setContent {
+            UsbTerminalTheme {
+                TerminalOutput(
+                    logs = logs,
+                    autoScroll = true,
+                    modifier = Modifier.testTag("terminal"),
+                )
+            }
+        }
+
+        // assert: composable exists even with empty logs and autoScroll enabled
+        composeRule.onNodeWithTag("terminal").assertExists().assertIsDisplayed()
+    }
+
+    @Test
+    fun terminalOutput_noAutoScroll_append_rendersNewItem() {
+        // arrange
+        val logs =
+            mutableStateListOf(
+                OutputText("Initial", OutputText.OutputType.TYPE_NORMAL),
+            )
+
+        composeRule.setContent {
+            UsbTerminalTheme {
+                TerminalOutput(
+                    logs = logs,
+                    autoScroll = false,
+                    modifier = Modifier.testTag("terminal"),
+                )
+            }
+        }
+
+        // act: append a new line while autoScroll is disabled
+        composeRule.runOnUiThread {
+            logs.add(OutputText("Next", OutputText.OutputType.TYPE_NORMAL))
+        }
+        composeRule.waitForIdle()
+
+        // assert: new item is rendered (if condition path with autoScroll=false evaluated)
+        composeRule.onNodeWithText("Next").assertIsDisplayed()
     }
 }

--- a/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
@@ -1,7 +1,6 @@
 package org.kabiri.android.usbterminal
 
 import android.os.Bundle
-import android.text.method.ScrollingMovementMethod
 import android.util.Log
 import android.view.KeyEvent
 import android.view.Menu
@@ -11,21 +10,19 @@ import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.Button
 import android.widget.EditText
-import android.widget.TextView
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
-import androidx.compose.runtime.collectAsState
-import androidx.compose.ui.platform.ComposeView
-import org.kabiri.android.usbterminal.ui.theme.UsbTerminalTheme
-import org.kabiri.android.usbterminal.ui.terminal.TerminalOutput
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import org.kabiri.android.usbterminal.ui.setting.SettingModalBottomSheet
 import org.kabiri.android.usbterminal.ui.setting.SettingViewModel
-import org.kabiri.android.usbterminal.util.scrollToLastLine
+import org.kabiri.android.usbterminal.ui.terminal.TerminalOutput
+import org.kabiri.android.usbterminal.ui.theme.UsbTerminalTheme
 import org.kabiri.android.usbterminal.viewmodel.MainActivityViewModel
 
 private const val TAG = "MainActivity"

--- a/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
@@ -16,9 +16,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.launch
 import org.kabiri.android.usbterminal.ui.setting.SettingModalBottomSheet
 import org.kabiri.android.usbterminal.ui.setting.SettingViewModel
 import org.kabiri.android.usbterminal.ui.terminal.TerminalOutput
@@ -35,6 +33,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         viewModel.startObservingUsbDevice()
+        viewModel.startObservingTerminalOutput()
         setContentView(R.layout.activity_main)
 
         val rootView = findViewById<View>(R.id.root_view)
@@ -70,9 +69,6 @@ class MainActivity : AppCompatActivity() {
                 )
             }
         }
-
-        // Start producing output into viewModel.output2 used by Compose list
-        lifecycleScope.launch { viewModel.getLiveOutput() }
 
         fun sendCommand() {
             val input = etInput.text.toString()

--- a/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
@@ -64,7 +64,7 @@ class MainActivity : AppCompatActivity() {
             UsbTerminalTheme {
                 val autoScrollEnabled = settingViewModel.currentAutoScroll.collectAsState(initial = true).value
                 TerminalOutput(
-                    logs = viewModel.output2,
+                    logs = viewModel.output,
                     autoScroll = autoScrollEnabled,
                 )
             }

--- a/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
@@ -32,165 +32,175 @@ interface IArduinoRepository {
     val messageFlow: Flow<String>
     val infoMessageFlow: Flow<String>
     val errorMessageFlow: Flow<String>
+
     fun disconnect()
+
     fun openDeviceAndPort(device: UsbDevice)
+
     fun serialWrite(command: String): Boolean
 }
 
 internal class ArduinoRepository
-@Inject constructor(
-    private val context: Context,
-    private val arduinoSerialReceiver: ArduinoSerialReceiver,
-    private val getBaudRate: IGetCustomBaudRateUseCase,
-): IArduinoRepository {
+    @Inject
+    constructor(
+        private val context: Context,
+        private val arduinoSerialReceiver: ArduinoSerialReceiver,
+        private val getBaudRate: IGetCustomBaudRateUseCase,
+    ) : IArduinoRepository {
+        private var currentBaudRate = DEFAULT_BAUD_RATE // Default value
 
-    private var currentBaudRate = DEFAULT_BAUD_RATE // Default value
+        private val _messageFlow = MutableStateFlow("")
+        override val messageFlow: Flow<String>
+            get() =
+                _messageFlow
+                    .combine(arduinoSerialReceiver.liveOutput) { a, b -> a + b }
 
-    private val _messageFlow = MutableStateFlow("")
-    override val messageFlow: Flow<String>
-        get() = _messageFlow
-            .combine(arduinoSerialReceiver.liveOutput) { a, b -> a + b }
+        private val _infoMessageFlow = MutableStateFlow("")
+        override val infoMessageFlow: Flow<String>
+            get() =
+                _infoMessageFlow
+                    .combine(arduinoSerialReceiver.liveInfoOutput) { a, b -> a + b }
 
-    private val _infoMessageFlow = MutableStateFlow("")
-    override val infoMessageFlow: Flow<String>
-        get() = _infoMessageFlow
-            .combine(arduinoSerialReceiver.liveInfoOutput) { a, b -> a + b }
+        private val _errorMessageFlow = MutableStateFlow("")
+        override val errorMessageFlow: Flow<String>
+            get() =
+                _errorMessageFlow
+                    .combine(arduinoSerialReceiver.liveErrorOutput) { a, b -> a + b }
 
-    private val _errorMessageFlow = MutableStateFlow("")
-    override val errorMessageFlow: Flow<String>
-        get() = _errorMessageFlow
-            .combine(arduinoSerialReceiver.liveErrorOutput) { a, b -> a + b }
+        private var usbManager: UsbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
+        private lateinit var connection: UsbDeviceConnection
+        private lateinit var serialPort: UsbSerialDevice
 
-    private var usbManager: UsbManager = context.getSystemService(Context.USB_SERVICE) as UsbManager
-    private lateinit var connection: UsbDeviceConnection
-    private lateinit var serialPort: UsbSerialDevice
-
-    init {
-        observeBaudRate()
-    }
-
-    override fun disconnect() {
-        try {
-            if (::connection.isInitialized) connection.close()
-            _messageFlow.value = context.getString(R.string.helper_info_serial_connection_closed)
-        } catch (e: UninitializedPropertyAccessException) {
-            _errorMessageFlow.value =
-                context.getString(R.string.helper_error_connection_not_ready_to_close)
-
-            _errorMessageFlow.value = "${e.localizedMessage}"
-        } catch (e: Exception) {
-            _errorMessageFlow.value = context.getString(
-                    R.string.helper_error_connection_failed_to_close
-                )
-            _errorMessageFlow.value = "${e.localizedMessage}"
-        }
-    }
-
-    /**
-     * This method should be called after the permission is granted to access the Arduino via USB.
-     */
-    override fun openDeviceAndPort(device: UsbDevice) {
-        try {
-            // setup the device communication.
-            connection = usbManager.openDevice(device)
-            serialPort = UsbSerialDevice.createUsbSerialDevice(device, connection)
-        } catch (e: IllegalStateException) {
-            Log.e(TAG, "${e.message}")
-            _errorMessageFlow.value =
-                context.getString(R.string.helper_error_connection_closed_unexpectedly)
-        } catch (e: NullPointerException) {
-            Log.e(TAG, "${e.message}")
-            _errorMessageFlow.value = context.getString(
-                R.string.helper_error_connection_failed_to_open)
-        } catch (e: Exception) {
-            Log.e(TAG, "${e.message}")
-            _errorMessageFlow.value =
-                context.getString(R.string.helper_error_connection_failed_to_open_unknown)
+        init {
+            observeBaudRate()
         }
 
-        if (::serialPort.isInitialized)
-            prepareSerialPort(serialPort)
-        else {
-            _infoMessageFlow.value = context.getString(R.string.helper_error_serial_port_is_null)
-            if (::connection.isInitialized) connection.close()
-        }
-    }
-
-    /**
-     * Prepare the serial port to interact with Arduino
-     * and register the read callback to read the serial messages from Arduino.
-     */
-    private fun prepareSerialPort(serialPort: UsbSerialDevice) {
-        serialPort.let {
-            if (it.open()) {
-                // init the serial port and set connection params.
-                Log.d(TAG, "current baud rate = $currentBaudRate")
-                it.setBaudRate(currentBaudRate)
-                it.setDataBits(UsbSerialInterface.DATA_BITS_8)
-                it.setStopBits(UsbSerialInterface.STOP_BITS_1)
-                it.setParity(UsbSerialInterface.PARITY_NONE)
-                it.setFlowControl(UsbSerialInterface.FLOW_CONTROL_OFF)
-                it.read(arduinoSerialReceiver) // messages will be received from the receiver.
-                _infoMessageFlow.value =
-                    context.getString(R.string.helper_info_serial_connection_opened)
-            } else { // serial port not opened.
+        override fun disconnect() {
+            try {
+                if (::connection.isInitialized) connection.close()
+                _messageFlow.value = context.getString(R.string.helper_info_serial_connection_closed)
+            } catch (e: UninitializedPropertyAccessException) {
                 _errorMessageFlow.value =
-                    context.getString(R.string.helper_error_serial_connection_not_opened)
+                    context.getString(R.string.helper_error_connection_not_ready_to_close)
+
+                _errorMessageFlow.value = "${e.localizedMessage}"
+            } catch (e: Exception) {
+                _errorMessageFlow.value =
+                    context.getString(R.string.helper_error_connection_failed_to_close)
+                _errorMessageFlow.value = "${e.localizedMessage}"
             }
         }
-    }
 
-    /**
-     * Send a serial message to the connected Arduino.
-     */
-    override fun serialWrite(command: String): Boolean {
-        return try {
-            if (::serialPort.isInitialized && command.isNotBlank()) {
-                serialPort.write(command.toByteArray())
-                true
+        /**
+         * This method should be called after the permission is granted to access the Arduino via USB.
+         */
+        override fun openDeviceAndPort(device: UsbDevice) {
+            try {
+                // setup the device communication.
+                connection = usbManager.openDevice(device)
+                serialPort = UsbSerialDevice.createUsbSerialDevice(device, connection)
+            } catch (e: IllegalStateException) {
+                Log.e(TAG, "${e.message}")
+                _errorMessageFlow.value =
+                    context.getString(R.string.helper_error_connection_closed_unexpectedly)
+            } catch (e: NullPointerException) {
+                Log.e(TAG, "${e.message}")
+                _errorMessageFlow.value =
+                    context.getString(R.string.helper_error_connection_failed_to_open)
+            } catch (e: Exception) {
+                Log.e(TAG, "${e.message}")
+                _errorMessageFlow.value =
+                    context.getString(R.string.helper_error_connection_failed_to_open_unknown)
+            }
+
+            if (::serialPort.isInitialized) {
+                prepareSerialPort(serialPort)
             } else {
-                _errorMessageFlow.value =
-                    context.getString(R.string.helper_error_serial_port_is_null)
-                false
+                _infoMessageFlow.value = context.getString(R.string.helper_error_serial_port_is_null)
+                if (::connection.isInitialized) connection.close()
             }
-        } catch (e: Exception) {
-            _errorMessageFlow.value = context.getString(R.string.helper_error_write_problem) +
-                    " \n${e.localizedMessage}"
-            Log.e(TAG, "$e")
-            false
         }
-    }
 
-    /**
-     * Listen for changes in baudRate set by the user
-     */
-    private fun observeBaudRate() {
-        CoroutineScope(Dispatchers.IO).launch {
-            getBaudRate().collect { baudRate ->
-                currentBaudRate = baudRate
-                _infoMessageFlow.value = String.format(
-                    context.getString(R.string.helper_info_baud_rate_applying), baudRate)
-                if (::serialPort.isInitialized) {
-                    updateSerialPortBaudRate(baudRate)
-                    _infoMessageFlow.value = String.format(
-                        context.getString(R.string.helper_info_baud_rate_applied), baudRate)
-                } else {
+        /**
+         * Prepare the serial port to interact with Arduino
+         * and register the read callback to read the serial messages from Arduino.
+         */
+        private fun prepareSerialPort(serialPort: UsbSerialDevice) {
+            serialPort.let {
+                if (it.open()) {
+                    // init the serial port and set connection params.
+                    Log.d(TAG, "current baud rate = $currentBaudRate")
+                    it.setBaudRate(currentBaudRate)
+                    it.setDataBits(UsbSerialInterface.DATA_BITS_8)
+                    it.setStopBits(UsbSerialInterface.STOP_BITS_1)
+                    it.setParity(UsbSerialInterface.PARITY_NONE)
+                    it.setFlowControl(UsbSerialInterface.FLOW_CONTROL_OFF)
+                    it.read(arduinoSerialReceiver) // messages will be received from the receiver.
+                    _infoMessageFlow.value =
+                        context.getString(R.string.helper_info_serial_connection_opened)
+                } else { // serial port not opened.
                     _errorMessageFlow.value =
-                        context.getString(R.string.helper_error_baud_rate_failed_to_apply_no_connection)
+                        context.getString(R.string.helper_error_serial_connection_not_opened)
                 }
             }
         }
-    }
 
-    /**
-     * Update value of current baud rate to new one from the user
-     */
-    private fun updateSerialPortBaudRate(baudRate: Int) {
-        try {
-            serialPort.setBaudRate(baudRate)
-        } catch (e: Exception) {
-            _errorMessageFlow.value = context.getString(R.string.helper_error_applying_baud_rate) +
+        /**
+         * Send a serial message to the connected Arduino.
+         */
+        override fun serialWrite(command: String): Boolean =
+            try {
+                if (::serialPort.isInitialized && command.isNotBlank()) {
+                    serialPort.write(command.toByteArray())
+                    true
+                } else {
+                    _errorMessageFlow.value =
+                        context.getString(R.string.helper_error_serial_port_is_null)
+                    false
+                }
+            } catch (e: Exception) {
+                _errorMessageFlow.value = context.getString(R.string.helper_error_write_problem) +
                     " \n${e.localizedMessage}"
+                Log.e(TAG, "$e")
+                false
+            }
+
+        /**
+         * Listen for changes in baudRate set by the user
+         */
+        private fun observeBaudRate() {
+            CoroutineScope(Dispatchers.IO).launch {
+                getBaudRate().collect { baudRate ->
+                    currentBaudRate = baudRate
+                    _infoMessageFlow.value =
+                        String.format(
+                            context.getString(R.string.helper_info_baud_rate_applying),
+                            baudRate,
+                        )
+                    if (::serialPort.isInitialized) {
+                        updateSerialPortBaudRate(baudRate)
+                        _infoMessageFlow.value =
+                            String.format(
+                                context.getString(R.string.helper_info_baud_rate_applied),
+                                baudRate,
+                            )
+                    } else {
+                        _errorMessageFlow.value =
+                            context.getString(R.string.helper_error_baud_rate_failed_to_apply_no_connection)
+                    }
+                }
+            }
+        }
+
+        /**
+         * Update value of current baud rate to new one from the user
+         */
+        private fun updateSerialPortBaudRate(baudRate: Int) {
+            try {
+                serialPort.setBaudRate(baudRate)
+            } catch (e: Exception) {
+                _errorMessageFlow.value = context.getString(R.string.helper_error_applying_baud_rate) +
+                    " \n${e.localizedMessage}"
+            }
         }
     }
-}

--- a/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
@@ -77,12 +77,12 @@ internal class ArduinoRepository
             _errorMessageFlow.value =
                 context.getString(R.string.helper_error_connection_not_ready_to_close)
 
-            _errorMessageFlow.value = "${e.localizedMessage}\n"
+            _errorMessageFlow.value = "${e.localizedMessage}"
         } catch (e: Exception) {
             _errorMessageFlow.value = context.getString(
                     R.string.helper_error_connection_failed_to_close
                 )
-            _errorMessageFlow.value = "${e.localizedMessage}\n"
+            _errorMessageFlow.value = "${e.localizedMessage}"
         }
     }
 
@@ -147,8 +147,6 @@ internal class ArduinoRepository
         return try {
             if (::serialPort.isInitialized && command.isNotBlank()) {
                 serialPort.write(command.toByteArray())
-                // go to next line because the answer might be sent in more than one part.
-                _messageFlow.value = context.getString(R.string.next_line)
                 true
             } else {
                 _errorMessageFlow.value =
@@ -157,7 +155,7 @@ internal class ArduinoRepository
             }
         } catch (e: Exception) {
             _errorMessageFlow.value = context.getString(R.string.helper_error_write_problem) +
-                    " \n${e.localizedMessage}\n"
+                    " \n${e.localizedMessage}"
             Log.e(TAG, "$e")
             false
         }

--- a/app/src/main/java/org/kabiri/android/usbterminal/model/OutputText.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/model/OutputText.kt
@@ -8,23 +8,23 @@ import android.text.style.TextAppearanceSpan
  */
 data class OutputText(
     val text: String,
-    val type: OutputType
+    val type: OutputType,
 ) {
-
     enum class OutputType {
         TYPE_NORMAL,
         TYPE_INFO,
-        TYPE_ERROR
+        TYPE_ERROR,
     }
 
-    fun getAppearance(context: Context): TextAppearanceSpan {
-        return when (this.type) {
+    fun getAppearance(context: Context): TextAppearanceSpan =
+        when (this.type) {
             OutputType.TYPE_NORMAL ->
                 TextAppearanceSpan(context, android.R.style.TextAppearance_Material)
+
             OutputType.TYPE_INFO ->
                 TextAppearanceSpan(context, android.R.style.TextAppearance_Material_Small)
+
             OutputType.TYPE_ERROR ->
                 TextAppearanceSpan(context, android.R.style.TextAppearance_Material_Large)
         }
-    }
 }

--- a/app/src/main/java/org/kabiri/android/usbterminal/model/OutputText.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/model/OutputText.kt
@@ -1,8 +1,5 @@
 package org.kabiri.android.usbterminal.model
 
-import android.content.Context
-import android.text.style.TextAppearanceSpan
-
 /**
  * Created by Ali Kabiri on 21.04.20.
  */
@@ -15,16 +12,4 @@ data class OutputText(
         TYPE_INFO,
         TYPE_ERROR,
     }
-
-    fun getAppearance(context: Context): TextAppearanceSpan =
-        when (this.type) {
-            OutputType.TYPE_NORMAL ->
-                TextAppearanceSpan(context, android.R.style.TextAppearance_Material)
-
-            OutputType.TYPE_INFO ->
-                TextAppearanceSpan(context, android.R.style.TextAppearance_Material_Small)
-
-            OutputType.TYPE_ERROR ->
-                TextAppearanceSpan(context, android.R.style.TextAppearance_Material_Large)
-        }
 }

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -1,5 +1,6 @@
 package org.kabiri.android.usbterminal.ui.terminal
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -33,6 +34,7 @@ internal fun TerminalOutput(
         modifier = modifier,
         state = listState,
         contentPadding = PaddingValues(vertical = 8.dp),
+        verticalArrangement = Arrangement.Bottom,
     ) {
         itemsIndexed(logs, key = { index, item -> index }) { _, item ->
             val color =

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -67,7 +67,7 @@ internal fun TerminalOutput(
                     else -> MaterialTheme.colorScheme.onBackground
                 }
             Text(
-                text = item.text.trimEnd('\n'),
+                text = item.text,
                 color = color,
                 style = MaterialTheme.typography.bodyMedium,
                 maxLines = Int.MAX_VALUE,

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -1,0 +1,53 @@
+package org.kabiri.android.usbterminal.ui.terminal
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshots.SnapshotStateList
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.kabiri.android.usbterminal.model.OutputText
+
+@Composable
+internal fun TerminalOutput(
+    logs: SnapshotStateList<OutputText>,
+    autoScroll: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberLazyListState()
+
+    // Auto-scroll to bottom when new items arrive
+    LaunchedEffect(logs.size, autoScroll) {
+        if (autoScroll && logs.isNotEmpty()) {
+            listState.scrollToItem(logs.lastIndex)
+        }
+    }
+
+    LazyColumn(
+        modifier = modifier,
+        state = listState,
+        contentPadding = PaddingValues(vertical = 8.dp),
+    ) {
+        itemsIndexed(logs, key = { index, item -> index }) { _, item ->
+            val color =
+                when (item.type) {
+                    OutputText.OutputType.TYPE_ERROR -> MaterialTheme.colorScheme.error
+                    OutputText.OutputType.TYPE_INFO -> MaterialTheme.colorScheme.onBackground
+                    else -> MaterialTheme.colorScheme.onBackground
+                }
+            Text(
+                text = item.text.trimEnd('\n'),
+                color = color,
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = Int.MAX_VALUE,
+                overflow = TextOverflow.Clip,
+            )
+        }
+    }
+}

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -1,5 +1,7 @@
 package org.kabiri.android.usbterminal.ui.terminal
 
+import android.widget.Toast
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
@@ -9,10 +11,16 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import org.kabiri.android.usbterminal.R
 import org.kabiri.android.usbterminal.model.OutputText
 
 @Composable
@@ -30,8 +38,23 @@ internal fun TerminalOutput(
         }
     }
 
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
+
+    // Concatenate all logs as plain text for copy action
+    val allText = remember(logs.size) { logs.joinToString(separator = "") { it.text } }
+
+    val longClickMessage = stringResource(R.string.copied_to_clipboard)
+
     LazyColumn(
-        modifier = modifier,
+        modifier =
+            modifier.combinedClickable(
+                onClick = {},
+                onLongClick = {
+                    clipboard.setText(AnnotatedString(allText))
+                    Toast.makeText(context, longClickMessage, Toast.LENGTH_SHORT).show()
+                },
+            ),
         state = listState,
         contentPadding = PaddingValues(vertical = 8.dp),
         verticalArrangement = Arrangement.Bottom,

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -59,7 +59,7 @@ internal fun TerminalOutput(
         contentPadding = PaddingValues(vertical = 8.dp),
         verticalArrangement = Arrangement.Bottom,
     ) {
-        itemsIndexed(logs, key = { index, item -> index }) { _, item ->
+        itemsIndexed(logs, key = { index, _ -> index }) { _, item ->
             val color =
                 when (item.type) {
                     OutputText.OutputType.TYPE_ERROR -> MaterialTheme.colorScheme.error

--- a/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
@@ -46,7 +46,7 @@ internal class MainActivityViewModel
         val errorMessage: StateFlow<String>
             get() = _errorMessageFlow
 
-        val output2 = SnapshotStateList<OutputText>()
+        val output = SnapshotStateList<OutputText>()
 
         internal fun startObservingUsbDevice() {
             // Subscribe to USB device changes.
@@ -110,7 +110,7 @@ internal class MainActivityViewModel
 
         fun serialWrite(command: String): Boolean {
             val outputText = OutputText(command, OutputText.OutputType.TYPE_NORMAL)
-            output2.add(outputText)
+            output.add(outputText)
             return arduinoUseCase.serialWrite(command)
         }
 
@@ -156,7 +156,7 @@ internal class MainActivityViewModel
                 arduinoDefaultOutput,
                 arduinoInfoOutput,
                 arduinoErrorOutput,
-            ).onEach { output2.add(it) }
+            ).onEach { output.add(it) }
                 .launchIn(viewModelScope)
         }
     }

--- a/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
@@ -8,10 +8,12 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import org.kabiri.android.usbterminal.R
 import org.kabiri.android.usbterminal.domain.IArduinoUseCase
@@ -64,7 +66,8 @@ internal class MainActivityViewModel
                     resourceProvider.getString(R.string.helper_error_usb_devices_not_attached)
                 return // no usb devices found
             }
-            val device = usbDeviceList.firstOrNull { it.isOfficialArduinoBoard() || it.isCloneArduinoBoard() }
+            val device =
+                usbDeviceList.firstOrNull { it.isOfficialArduinoBoard() || it.isCloneArduinoBoard() }
             if (device == null) {
                 _errorMessageFlow.value =
                     resourceProvider.getString(R.string.helper_error_arduino_device_not_found)
@@ -106,80 +109,54 @@ internal class MainActivityViewModel
             }
 
         fun serialWrite(command: String): Boolean {
-            val outputText = OutputText(command, OutputText.OutputType.TYPE_INFO)
+            val outputText = OutputText(command, OutputText.OutputType.TYPE_NORMAL)
             output2.add(outputText)
             return arduinoUseCase.serialWrite(command)
         }
 
         /**
-         * Transforms the outputs from ArduinoHelper into spannable text
-         * and merges them in one single flow
+         * Starts emitting all output sources to the snapshot list used by the UI.
+         * Emits every item (including repeats) with its type.
          */
-        suspend fun getLiveOutput(): StateFlow<OutputText> {
+        fun startObservingTerminalOutput() {
             val infoOutput: Flow<OutputText> =
-                infoMessage.map {
-                    val outputText = OutputText(it, OutputText.OutputType.TYPE_INFO)
-                    output2.add(outputText)
-                    return@map outputText
-                }
+                infoMessage
+                    .filter { it.isNotEmpty() }
+                    .map { OutputText(it, OutputText.OutputType.TYPE_INFO) }
 
             val errorOutput: Flow<OutputText> =
-                errorMessage.map {
-                    val outputText = OutputText(it, OutputText.OutputType.TYPE_ERROR)
-                    output2.add(outputText)
-                    return@map outputText
-                }
+                errorMessage
+                    .filter { it.isNotEmpty() }
+                    .map { OutputText(it, OutputText.OutputType.TYPE_ERROR) }
 
             val usbInfoOutput: Flow<OutputText> =
-                usbUseCase.infoMessageFlow.map {
-                    val outputText = OutputText(it, OutputText.OutputType.TYPE_INFO)
-                    output2.add(outputText)
-                    return@map outputText
-                }
+                usbUseCase.infoMessageFlow
+                    .filter { it.isNotEmpty() }
+                    .map { OutputText(it, OutputText.OutputType.TYPE_INFO) }
 
             val arduinoDefaultOutput: Flow<OutputText> =
-                arduinoUseCase.messageFlow.map {
-                    val outputText = OutputText(it, OutputText.OutputType.TYPE_NORMAL)
-                    output2.add(outputText)
-                    return@map outputText
-                }
+                arduinoUseCase.messageFlow
+                    .filter { it.isNotEmpty() }
+                    .map { OutputText(it, OutputText.OutputType.TYPE_NORMAL) }
 
             val arduinoInfoOutput: Flow<OutputText> =
-                arduinoUseCase.infoMessageFlow.map {
-                    val outputText = OutputText(it, OutputText.OutputType.TYPE_INFO)
-                    output2.add(outputText)
-                    return@map outputText
-                }
+                arduinoUseCase.infoMessageFlow
+                    .filter { it.isNotEmpty() }
+                    .map { OutputText(it, OutputText.OutputType.TYPE_INFO) }
 
             val arduinoErrorOutput: Flow<OutputText> =
-                arduinoUseCase.errorMessageFlow.map {
-                    val outputText = OutputText(it, OutputText.OutputType.TYPE_ERROR)
-                    output2.add(outputText)
-                    return@map outputText
-                }
+                arduinoUseCase.errorMessageFlow
+                    .filter { it.isNotEmpty() }
+                    .map { OutputText(it, OutputText.OutputType.TYPE_ERROR) }
 
-            return combine(
+            merge(
                 infoOutput,
                 errorOutput,
+                usbInfoOutput,
                 arduinoDefaultOutput,
                 arduinoInfoOutput,
                 arduinoErrorOutput,
-            ) { info, error, arduinoDefault, arduinoInfo, arduinoError ->
-                // Prioritize error output over info, then normal.
-                when {
-                    error.text.isNotEmpty() -> error
-                    info.text.isNotEmpty() -> info
-                    arduinoError.text.isNotEmpty() -> arduinoError
-                    arduinoInfo.text.isNotEmpty() -> arduinoInfo
-                    else -> arduinoDefault
-                }
-            }.combine(usbInfoOutput) { outputText, usbInfo ->
-                // Prioritize USB info output over the rest.
-                if (usbInfo.text.isNotEmpty()) {
-                    usbInfo
-                } else {
-                    outputText
-                }
-            }.stateIn(viewModelScope)
+            ).onEach { output2.add(it) }
+                .launchIn(viewModelScope)
         }
     }

--- a/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
@@ -54,7 +54,7 @@ internal class MainActivityViewModel
             // Subscribe to USB device changes.
             viewModelScope.launch {
                 usbUseCase.usbDevice.collect { device ->
-                    _infoMessageFlow.value = "device discovered: ${device?.vendorId}\n"
+                    _infoMessageFlow.value = "device discovered: ${device?.vendorId}"
                     // TODO: DROID-17 - check if this line is required after DROID-17 is done
                     device?.let { openDeviceAndPort(it) }
                 }
@@ -110,7 +110,7 @@ internal class MainActivityViewModel
             }
 
         fun serialWrite(command: String): Boolean {
-            _outputLive.value = "${output.value}\n$command\n"
+            _outputLive.value = "${output.value}\n$command"
             val outputText = OutputText(command, OutputText.OutputType.TYPE_INFO)
             output2.add(outputText)
             return arduinoUseCase.serialWrite(command)

--- a/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
@@ -111,6 +111,8 @@ internal class MainActivityViewModel
 
         fun serialWrite(command: String): Boolean {
             _outputLive.value = "${output.value}\n$command\n"
+            val outputText = OutputText(command, OutputText.OutputType.TYPE_INFO)
+            output2.add(outputText)
             return arduinoUseCase.serialWrite(command)
         }
 

--- a/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
@@ -44,10 +44,6 @@ internal class MainActivityViewModel
         val errorMessage: StateFlow<String>
             get() = _errorMessageFlow
 
-        private val _outputLive = MutableStateFlow("")
-        val output: StateFlow<String>
-            get() = _outputLive
-
         val output2 = SnapshotStateList<OutputText>()
 
         internal fun startObservingUsbDevice() {
@@ -110,7 +106,6 @@ internal class MainActivityViewModel
             }
 
         fun serialWrite(command: String): Boolean {
-            _outputLive.value = "${output.value}\n$command"
             val outputText = OutputText(command, OutputText.OutputType.TYPE_INFO)
             output2.add(outputText)
             return arduinoUseCase.serialWrite(command)
@@ -123,7 +118,6 @@ internal class MainActivityViewModel
         suspend fun getLiveOutput(): StateFlow<OutputText> {
             val infoOutput: Flow<OutputText> =
                 infoMessage.map {
-                    _outputLive.value = _outputLive.value + it
                     val outputText = OutputText(it, OutputText.OutputType.TYPE_INFO)
                     output2.add(outputText)
                     return@map outputText
@@ -131,7 +125,6 @@ internal class MainActivityViewModel
 
             val errorOutput: Flow<OutputText> =
                 errorMessage.map {
-                    _outputLive.value = _outputLive.value + it
                     val outputText = OutputText(it, OutputText.OutputType.TYPE_ERROR)
                     output2.add(outputText)
                     return@map outputText
@@ -139,7 +132,6 @@ internal class MainActivityViewModel
 
             val usbInfoOutput: Flow<OutputText> =
                 usbUseCase.infoMessageFlow.map {
-                    _outputLive.value = _outputLive.value + it
                     val outputText = OutputText(it, OutputText.OutputType.TYPE_INFO)
                     output2.add(outputText)
                     return@map outputText
@@ -147,7 +139,6 @@ internal class MainActivityViewModel
 
             val arduinoDefaultOutput: Flow<OutputText> =
                 arduinoUseCase.messageFlow.map {
-                    _outputLive.value = _outputLive.value + it
                     val outputText = OutputText(it, OutputText.OutputType.TYPE_NORMAL)
                     output2.add(outputText)
                     return@map outputText
@@ -155,7 +146,6 @@ internal class MainActivityViewModel
 
             val arduinoInfoOutput: Flow<OutputText> =
                 arduinoUseCase.infoMessageFlow.map {
-                    _outputLive.value = _outputLive.value + it
                     val outputText = OutputText(it, OutputText.OutputType.TYPE_INFO)
                     output2.add(outputText)
                     return@map outputText
@@ -163,7 +153,6 @@ internal class MainActivityViewModel
 
             val arduinoErrorOutput: Flow<OutputText> =
                 arduinoUseCase.errorMessageFlow.map {
-                    _outputLive.value = _outputLive.value + it
                     val outputText = OutputText(it, OutputText.OutputType.TYPE_ERROR)
                     output2.add(outputText)
                     return@map outputText

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -28,15 +28,12 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <TextView
-        android:id="@+id/tvOutput"
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/composeOutput"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginStart="16dp"
         android:layout_marginEnd="16dp"
-        android:gravity="bottom"
-        android:scrollbars="vertical"
-        android:text="@{viewModel.output}"
         app:layout_constraintBottom_toTopOf="@id/etInput"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="title_connect">Connect</string>
     <string name="title_disconnect">Disconnect</string>
     <string name="title_settings">Settings</string>
+    <string name="copied_to_clipboard">Copied to clipboard</string>
 
     <!-- Home Screen -->
     <string name="home_bt_enter">Enter</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,6 @@
 <resources>
 
     <!--NON-TRANSLATABLE-->
-    <string translatable="false" name="next_line">\n</string>
 
     <!--TRANSLATABLE-->
     <string name="app_name">USBTerminal</string>
@@ -33,29 +32,29 @@
     <string name="bt_joystick_backward">Go Backward</string>
 
     <!-- Messages -->
-    <string name="helper_error_serial_port_is_null">Serial Port is null: The device might be disconnected.\n</string>
-    <string name="helper_error_arduino_device_not_found">Arduino Device not found (or the device might be an unknown clone).\n</string>
-    <string name="helper_error_connecting_anyway">Connecting anyway (may misbehave)…\n</string>
-    <string name="helper_error_usb_devices_not_attached">No USB devices are attached\n</string>
-    <string name="helper_error_serial_connection_not_opened">Port not opened - There might be a problem with the serial connection to Arduino\n</string>
-    <string name="helper_error_write_problem">Serial Write encountered an error:\n</string>
-    <string name="helper_error_connection_closed_unexpectedly">Device connection was closed unexpectedly\n</string>
-    <string name="helper_error_connection_failed_to_open">Failed to open device connection. Please make sure the device is connected and the USB cable and the port are healthy.\n</string>
-    <string name="helper_error_connection_failed_to_open_unknown">Failed to open device connection.\n</string>
-    <string name="helper_error_connection_not_ready_to_close">No device connection to close\n</string>
-    <string name="helper_error_connection_failed_to_close">Device connection failed to close\n</string>
-    <string name="helper_error_applying_baud_rate">Failed to apply baud rate…\n</string>
-    <string name="helper_error_baud_rate_failed_to_apply_no_connection">Please connect an Arduino via USB and click on the USB connection button to connect.\n</string>
-    <string name="helper_info_serial_connection_opened">Serial Connection Opened\n</string>
-    <string name="helper_info_serial_connection_closed">Serial Connection Closed\n</string>
-    <string name="helper_info_usb_permission_requested">Requested permission to access the USB device…\n</string>
-    <string name="helper_info_checking_attached_usb_devices">Checking attached USB devices…\n</string>
-    <string name="helper_info_baud_rate_applying">Baud rate: %d (can be changed in settings)\n</string>
-    <string name="helper_info_baud_rate_applied">Baud rate applied successfully: %d\n</string>
+    <string name="helper_error_serial_port_is_null">Serial Port is null: The device might be disconnected.</string>
+    <string name="helper_error_arduino_device_not_found">Arduino Device not found (or the device might be an unknown clone).</string>
+    <string name="helper_error_connecting_anyway">Connecting anyway (may misbehave)…</string>
+    <string name="helper_error_usb_devices_not_attached">No USB devices are attached</string>
+    <string name="helper_error_serial_connection_not_opened">Port not opened - There might be a problem with the serial connection to Arduino</string>
+    <string name="helper_error_write_problem">Serial Write encountered an error:</string>
+    <string name="helper_error_connection_closed_unexpectedly">Device connection was closed unexpectedly</string>
+    <string name="helper_error_connection_failed_to_open">Failed to open device connection. Please make sure the device is connected and the USB cable and the port are healthy.</string>
+    <string name="helper_error_connection_failed_to_open_unknown">Failed to open device connection.</string>
+    <string name="helper_error_connection_not_ready_to_close">No device connection to close</string>
+    <string name="helper_error_connection_failed_to_close">Device connection failed to close</string>
+    <string name="helper_error_applying_baud_rate">Failed to apply baud rate…</string>
+    <string name="helper_error_baud_rate_failed_to_apply_no_connection">Please connect an Arduino via USB and click on the USB connection button to connect.</string>
+    <string name="helper_info_serial_connection_opened">Serial Connection Opened</string>
+    <string name="helper_info_serial_connection_closed">Serial Connection Closed</string>
+    <string name="helper_info_usb_permission_requested">Requested permission to access the USB device…</string>
+    <string name="helper_info_checking_attached_usb_devices">Checking attached USB devices…</string>
+    <string name="helper_info_baud_rate_applying">Baud rate: %d (can be changed in settings)</string>
+    <string name="helper_info_baud_rate_applied">Baud rate applied successfully: %d</string>
 
-    <string name="breceiver_info_usb_permission_granted">"USB Permission granted for: \n"</string>
-    <string name="breceiver_error_usb_permission_denied">permission denied for device:\n</string>
-    <string name="breceiver_info_device_attached">Device attached\n</string>
-    <string name="breceiver_info_device_detached">Device detached\n</string>
-    <string name="breceiver_info_unknown_intent_action">intent.action was null\n</string>
+    <string name="breceiver_info_usb_permission_granted">"USB Permission granted for: "</string>
+    <string name="breceiver_error_usb_permission_denied">permission denied for device:</string>
+    <string name="breceiver_info_device_attached">Device attached</string>
+    <string name="breceiver_info_device_detached">Device detached</string>
+    <string name="breceiver_info_unknown_intent_action">intent.action was null</string>
 </resources>

--- a/app/src/test/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepositoryTest.kt
+++ b/app/src/test/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepositoryTest.kt
@@ -1,0 +1,199 @@
+package org.kabiri.android.usbterminal.data.repository
+
+import android.content.Context
+import android.hardware.usb.UsbDevice
+import android.hardware.usb.UsbDeviceConnection
+import android.hardware.usb.UsbManager
+import android.util.Log
+import com.felhr.usbserial.UsbSerialDevice
+import com.google.common.truth.Truth.assertThat
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.kabiri.android.usbterminal.R
+import org.kabiri.android.usbterminal.domain.IGetCustomBaudRateUseCase
+import org.kabiri.android.usbterminal.model.DEFAULT_BAUD_RATE
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ArduinoRepositoryTest {
+    private val mockContext: Context = mockk(relaxed = true)
+    private val mockUsbManager: UsbManager = mockk(relaxed = true)
+    private val mockConnection: UsbDeviceConnection = mockk(relaxed = true)
+    private val mockSerial: UsbSerialDevice = mockk(relaxed = true)
+    private val mockDevice: UsbDevice = mockk(relaxed = true)
+    private val receiver = ArduinoSerialReceiver()
+    private val mockGetBaud: IGetCustomBaudRateUseCase = mockk(relaxed = true)
+
+    private lateinit var sut: ArduinoRepository
+
+    @Before
+    fun setUp() {
+        mockkStatic(Log::class)
+        every { Log.d(any(), any()) } returns 1
+
+        every { mockContext.getSystemService(Context.USB_SERVICE) } returns mockUsbManager
+        every { mockGetBaud.invoke() } returns emptyFlow()
+        sut =
+            ArduinoRepository(
+                context = mockContext,
+                arduinoSerialReceiver = receiver,
+                getBaudRate = mockGetBaud,
+            )
+    }
+
+    @After
+    fun cleanUp() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `openDeviceAndPort opens serial and emits connection opened`() =
+        runTest {
+            // arrange
+            val expected = "opened"
+            mockkStatic(UsbSerialDevice::class)
+            every { mockUsbManager.openDevice(mockDevice) } returns mockConnection
+            every {
+                UsbSerialDevice.createUsbSerialDevice(
+                    mockDevice,
+                    mockConnection,
+                )
+            } returns mockSerial
+            every { mockSerial.open() } returns true
+            every { mockContext.getString(R.string.helper_info_serial_connection_opened) } returns expected
+
+            // act
+            sut.openDeviceAndPort(mockDevice)
+            advanceUntilIdle()
+
+            // assert
+            verify { mockUsbManager.openDevice(mockDevice) }
+            verify { mockSerial.open() }
+            verify { mockSerial.setBaudRate(DEFAULT_BAUD_RATE) }
+            verify { mockSerial.read(receiver) }
+            assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
+        }
+
+    @Test
+    fun `openDeviceAndPort emits error when serial port fails to open`() =
+        runTest {
+            // arrange
+            val expected = "not opened"
+            mockkStatic(UsbSerialDevice::class)
+            every { mockUsbManager.openDevice(mockDevice) } returns mockConnection
+            every {
+                UsbSerialDevice.createUsbSerialDevice(
+                    mockDevice,
+                    mockConnection,
+                )
+            } returns mockSerial
+            every { mockSerial.open() } returns false
+            every { mockContext.getString(R.string.helper_error_serial_connection_not_opened) } returns expected
+
+            // act
+            sut.openDeviceAndPort(mockDevice)
+            advanceUntilIdle()
+
+            // assert
+            assertThat(sut.errorMessageFlow.first()).isEqualTo(expected)
+        }
+
+    @Test
+    fun `openDeviceAndPort emits info and closes when serial device is null`() =
+        runTest {
+            // arrange
+            val expected = "port null"
+            mockkStatic(UsbSerialDevice::class)
+            every { mockUsbManager.openDevice(mockDevice) } returns mockConnection
+            every { UsbSerialDevice.createUsbSerialDevice(mockDevice, mockConnection) } returns null
+            every { mockContext.getString(R.string.helper_error_serial_port_is_null) } returns expected
+
+            // act
+            sut.openDeviceAndPort(mockDevice)
+            advanceUntilIdle()
+
+            // assert
+            verify { mockConnection.close() }
+            assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
+        }
+
+    @Test
+    fun `serialWrite writes bytes when initialized`() =
+        runTest {
+            // arrange
+            val expected = "fakeCommand"
+            mockkStatic(UsbSerialDevice::class)
+            every { mockUsbManager.openDevice(mockDevice) } returns mockConnection
+            every {
+                UsbSerialDevice.createUsbSerialDevice(
+                    mockDevice,
+                    mockConnection,
+                )
+            } returns mockSerial
+            every { mockSerial.open() } returns true
+            every { mockContext.getString(any()) } returns "" // ignore other strings
+            sut.openDeviceAndPort(mockDevice)
+            advanceUntilIdle()
+
+            // act
+            val actual = sut.serialWrite(expected)
+
+            // assert
+            assertThat(actual).isTrue()
+            verify { mockSerial.write(expected.toByteArray()) }
+        }
+
+    @Test
+    fun `serialWrite emits error when not initialized`() =
+        runTest {
+            // arrange
+            val expected = "port null"
+            every { mockContext.getString(R.string.helper_error_serial_port_is_null) } returns expected
+
+            // act
+            val actual = sut.serialWrite("doesn't matter")
+
+            // assert
+            assertThat(actual).isFalse()
+            assertThat(sut.errorMessageFlow.first()).isEqualTo(expected)
+        }
+
+    @Test
+    fun `disconnect closes connection and emits closed info`() =
+        runTest {
+            // arrange
+            val expected = "closed"
+            val unexpected = "opened"
+            mockkStatic(UsbSerialDevice::class)
+            every { mockUsbManager.openDevice(mockDevice) } returns mockConnection
+            every {
+                UsbSerialDevice.createUsbSerialDevice(
+                    mockDevice,
+                    mockConnection,
+                )
+            } returns mockSerial
+            every { mockSerial.open() } returns true
+            every { mockContext.getString(R.string.helper_info_serial_connection_opened) } returns unexpected
+            every { mockContext.getString(R.string.helper_info_serial_connection_closed) } returns expected
+            sut.openDeviceAndPort(mockDevice)
+            advanceUntilIdle()
+
+            // act
+            sut.disconnect()
+            advanceUntilIdle()
+
+            // assert
+            verify { mockConnection.close() }
+            assertThat(sut.messageFlow.first()).isEqualTo(expected)
+        }
+}

--- a/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
@@ -246,7 +246,7 @@ internal class MainActivityViewModelTest {
         }
 
     @Test
-    fun `getLiveOutput emits arduinoInfo when only arduinoInfo is not empty`() =
+    fun `startObservingTerminalOutput appends arduinoInfo when only arduinoInfo is not empty`() =
         runTest {
             // arrange
             val arduinoDefaultFlow = MutableStateFlow("")
@@ -261,17 +261,18 @@ internal class MainActivityViewModelTest {
             every { mockResourceProvider.getString(any()) } returns ""
 
             // act
-            val outputFlow = sut.getLiveOutput()
+            sut.startObservingTerminalOutput()
             advanceUntilIdle()
-            val output = outputFlow.value
 
             // assert
-            assertThat(output.text).isEqualTo("arduino info message")
-            assertThat(output.type).isEqualTo(OutputText.OutputType.TYPE_INFO)
+            assertThat(sut.output2).isNotEmpty()
+            val last = sut.output2.last()
+            assertThat(last.text).isEqualTo("arduino info message")
+            assertThat(last.type).isEqualTo(OutputText.OutputType.TYPE_INFO)
         }
 
     @Test
-    fun `getLiveOutput emits arduinoDefault when all outputs are empty`() =
+    fun `startObservingTerminalOutput appends arduinoDefault when all outputs are empty`() =
         runTest {
             // arrange
             val arduinoDefaultFlow = MutableStateFlow("default message")
@@ -286,12 +287,13 @@ internal class MainActivityViewModelTest {
             every { mockResourceProvider.getString(any()) } returns ""
 
             // act
-            val outputFlow = sut.getLiveOutput()
+            sut.startObservingTerminalOutput()
             advanceUntilIdle()
-            val output = outputFlow.value
 
             // assert
-            assertThat(output.text).isEqualTo("default message")
-            assertThat(output.type).isEqualTo(OutputText.OutputType.TYPE_NORMAL)
+            assertThat(sut.output2).isNotEmpty()
+            val last = sut.output2.last()
+            assertThat(last.text).isEqualTo("default message")
+            assertThat(last.type).isEqualTo(OutputText.OutputType.TYPE_NORMAL)
         }
 }

--- a/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
@@ -180,7 +180,6 @@ internal class MainActivityViewModelTest {
             verify(exactly = 1) { mockUsbUseCase.requestPermission(fakeDevice) }
             assertThat(sut.infoMessage.value).isEqualTo("")
             assertThat(sut.errorMessage.value).isEqualTo("")
-            assertThat(sut.output.value).isEqualTo("")
         }
 
     @Test

--- a/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
@@ -241,7 +241,7 @@ internal class MainActivityViewModelTest {
             // assert
             verify { mockArduinoUsecase.serialWrite(expected) }
             assertThat(result).isTrue()
-            val outputText = sut.output2.last().text
+            val outputText = sut.output.last().text
             assertThat(outputText).contains(expected)
         }
 
@@ -265,8 +265,8 @@ internal class MainActivityViewModelTest {
             advanceUntilIdle()
 
             // assert
-            assertThat(sut.output2).isNotEmpty()
-            val last = sut.output2.last()
+            assertThat(sut.output).isNotEmpty()
+            val last = sut.output.last()
             assertThat(last.text).isEqualTo("arduino info message")
             assertThat(last.type).isEqualTo(OutputText.OutputType.TYPE_INFO)
         }
@@ -291,8 +291,8 @@ internal class MainActivityViewModelTest {
             advanceUntilIdle()
 
             // assert
-            assertThat(sut.output2).isNotEmpty()
-            val last = sut.output2.last()
+            assertThat(sut.output).isNotEmpty()
+            val last = sut.output.last()
             assertThat(last.text).isEqualTo("default message")
             assertThat(last.type).isEqualTo(OutputText.OutputType.TYPE_NORMAL)
         }

--- a/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
@@ -22,6 +22,7 @@ import org.junit.Test
 import org.kabiri.android.usbterminal.R
 import org.kabiri.android.usbterminal.domain.IArduinoUseCase
 import org.kabiri.android.usbterminal.domain.IUsbUseCase
+import org.kabiri.android.usbterminal.model.OutputText
 import org.kabiri.android.usbterminal.util.IResourceProvider
 import org.kabiri.android.usbterminal.util.isCloneArduinoBoard
 import org.kabiri.android.usbterminal.util.isOfficialArduinoBoard
@@ -241,7 +242,8 @@ internal class MainActivityViewModelTest {
             // assert
             verify { mockArduinoUsecase.serialWrite(expected) }
             assertThat(result).isTrue()
-            assertThat(sut.output.value).contains(expected)
+            val outputText = sut.output2.last().text
+            assertThat(outputText).contains(expected)
         }
 
     @Test

--- a/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
@@ -261,14 +261,6 @@ internal class MainActivityViewModelTest {
             every { mockUsbUseCase.infoMessageFlow } returns usbInfoFlow
             every { mockResourceProvider.getString(any()) } returns ""
 
-            // inject flows into ViewModel
-            sut =
-                MainActivityViewModel(
-                    arduinoUseCase = mockArduinoUsecase,
-                    usbUseCase = mockUsbUseCase,
-                    resourceProvider = mockResourceProvider,
-                )
-
             // act
             val outputFlow = sut.getLiveOutput()
             advanceUntilIdle()
@@ -276,7 +268,7 @@ internal class MainActivityViewModelTest {
 
             // assert
             assertThat(output.text).isEqualTo("arduino info message")
-            assertThat(output.type).isEqualTo(org.kabiri.android.usbterminal.model.OutputText.OutputType.TYPE_INFO)
+            assertThat(output.type).isEqualTo(OutputText.OutputType.TYPE_INFO)
         }
 
     @Test
@@ -294,14 +286,6 @@ internal class MainActivityViewModelTest {
             every { mockUsbUseCase.infoMessageFlow } returns usbInfoFlow
             every { mockResourceProvider.getString(any()) } returns ""
 
-            // inject flows into ViewModel
-            sut =
-                MainActivityViewModel(
-                    arduinoUseCase = mockArduinoUsecase,
-                    usbUseCase = mockUsbUseCase,
-                    resourceProvider = mockResourceProvider,
-                )
-
             // act
             val outputFlow = sut.getLiveOutput()
             advanceUntilIdle()
@@ -309,6 +293,6 @@ internal class MainActivityViewModelTest {
 
             // assert
             assertThat(output.text).isEqualTo("default message")
-            assertThat(output.type).isEqualTo(org.kabiri.android.usbterminal.model.OutputText.OutputType.TYPE_NORMAL)
+            assertThat(output.type).isEqualTo(OutputText.OutputType.TYPE_NORMAL)
         }
 }


### PR DESCRIPTION
- Allow copying the terminal output to the clipboard by long pressing the output
- Use a Compose list for the output and cleanup the previous TextView
- Change viewModel method `getLiveOutput ` to `startObservingTerminalOutput` to merge the output flows and avoid returning an unnecessary combined flow