### PR TITLE
DROID-21: Improve Terminal Output

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ android {
     }
 
     testOptions {
+        unitTests.isReturnDefaultValues = true
 
         animationsDisabled = true
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,7 +60,10 @@ android {
         named("release") {
             signingConfig = signingConfigs.findByName("release")
             isMinifyEnabled = true
-            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
         named("debug") {
             enableUnitTestCoverage = true
@@ -92,7 +95,6 @@ android {
     }
 
     namespace = "org.kabiri.android.usbterminal"
-
 }
 
 jacoco {
@@ -111,24 +113,33 @@ tasks.register<JacocoReport>("jacocoTestReport") {
         csv.required.set(false)
     }
 
-    val fileFilter = listOf(
-        "**/R.class",
-        "**/MainActivity.*",
-        "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*",
-        "**/*Test*.*", "android/**/*.*",
-        "**/Dagger*.*", "**/*_Hilt*.*", "**/*Hilt*.*",
-    )
-    val kotlinDebugTree = fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) { exclude(fileFilter) }
+    val fileFilter =
+        listOf(
+            "**/R.class",
+            "**/MainActivity.*",
+            "**/R$*.class",
+            "**/BuildConfig.*",
+            "**/Manifest*.*",
+            "**/*Test*.*",
+            "android/**/*.*",
+            "**/Dagger*.*",
+            "**/*_Hilt*.*",
+            "**/*Hilt*.*",
+        )
+    val kotlinDebugTree =
+        fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) { exclude(fileFilter) }
     val mainKotlinSrc = layout.projectDirectory.dir("src/main/kotlin")
     val mainJavaSrc = layout.projectDirectory.dir("src/main/java")
     sourceDirectories.from(files(mainKotlinSrc, mainJavaSrc))
     classDirectories.from(files(kotlinDebugTree))
-    executionData.from(fileTree(layout.buildDirectory) {
-        include(
-            "outputs/managed_device_code_coverage/**/*.ec",
-            "outputs/unit_test_code_coverage/**/*.exec",
-        )
-    })
+    executionData.from(
+        fileTree(layout.buildDirectory) {
+            include(
+                "outputs/managed_device_code_coverage/**/*.ec",
+                "outputs/unit_test_code_coverage/**/*.exec",
+            )
+        },
+    )
 }
 
 tasks.register<JacocoReport>("jacocoUiOnly") {
@@ -141,32 +152,43 @@ tasks.register<JacocoReport>("jacocoUiOnly") {
         csv.required.set(false)
     }
 
-    val fileFilter = listOf(
-        "**/R.class", "**/R$*.class", "**/BuildConfig.*", "**/Manifest*.*",
-        "**/*Test*.*", "android/**/*.*",
-        "**/Dagger*.*", "**/*_Hilt*.*", "**/*Hilt*.*",
-    )
-    val javaDebugTree = fileTree(layout.buildDirectory.dir("intermediates/javac/debug/classes")) { exclude(fileFilter) }
-    val kotlinDebugTree = fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) { exclude(fileFilter) }
+    val fileFilter =
+        listOf(
+            "**/R.class",
+            "**/R$*.class",
+            "**/BuildConfig.*",
+            "**/Manifest*.*",
+            "**/*Test*.*",
+            "android/**/*.*",
+            "**/Dagger*.*",
+            "**/*_Hilt*.*",
+            "**/*Hilt*.*",
+        )
+    val javaDebugTree =
+        fileTree(layout.buildDirectory.dir("intermediates/javac/debug/classes")) {
+            exclude(fileFilter)
+        }
+    val kotlinDebugTree =
+        fileTree(layout.buildDirectory.dir("tmp/kotlin-classes/debug")) { exclude(fileFilter) }
     val mainJavaSrc = layout.projectDirectory.dir("src/main/java")
     val mainKotlinSrc = layout.projectDirectory.dir("src/main/kotlin")
     sourceDirectories.from(files(mainJavaSrc, mainKotlinSrc))
     classDirectories.from(files(javaDebugTree, kotlinDebugTree))
-    executionData.from(fileTree(layout.buildDirectory) {
-        include(
-            "outputs/managed_device_code_coverage/**/*.ec",
-            "outputs/managed_device_code_coverage/**/*.exec"
-        )
-    })
+    executionData.from(
+        fileTree(layout.buildDirectory) {
+            include(
+                "outputs/managed_device_code_coverage/**/*.ec",
+                "outputs/managed_device_code_coverage/**/*.exec",
+            )
+        },
+    )
 }
-
-
 
 tasks.register("generateGoogleServicesJson") {
     doLast {
         val jsonFileName = "google-services.json"
         val json = File(projectDir, jsonFileName)
-        
+
         if (!json.exists() || json.length() == 0L) {
             val fileContent = System.getenv("GOOGLE_SERVICES_JSON")
             if (!fileContent.isNullOrBlank()) {
@@ -175,7 +197,7 @@ tasks.register("generateGoogleServicesJson") {
                 println("generated $jsonFileName")
             }
         }
-        
+
         // Check if the json file is empty
         if (!json.exists() || json.length() == 0L) {
             throw GradleException(
@@ -206,13 +228,15 @@ tasks.register("generateKsPropFile") {
         val configFileName = "keystore.properties"
         File(projectDir, configFileName).apply {
             createNewFile()
-            writeText("""
+            writeText(
+                """
                 # Gradle signing properties for app module
                 release.file=${System.getenv("USB_TERMINAL_KS_PATH")}
                 release.storePassword=${System.getenv("USB_TERMINAL_KS_PASSWORD")}
                 release.keyAlias=${System.getenv("USB_TERMINAL_KS_KEY_ALIAS")}
                 release.keyPassword=${System.getenv("USB_TERMINAL_KS_KEY_PASSWORD")}
-                """.trimIndent())
+                """.trimIndent(),
+            )
             println("generated ${this.path}")
         }
     }
@@ -223,9 +247,9 @@ tasks.register("generateAppDistKey") {
         val jsonFileName = "app-dist-key.json"
         val fileContent = System.getenv("GOOGLE_APP_DIST_FASTLANE_SERVICE_ACCOUNT")
         File(rootDir, jsonFileName).apply {
-                createNewFile()
-                writeText(fileContent)
-                println("generated ${this.path}")
+            createNewFile()
+            writeText(fileContent)
+            println("generated ${this.path}")
         }
     }
 }

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
@@ -44,8 +44,8 @@ class TerminalOutputAndroidTest {
 
         // assert
         composeRule.onNodeWithText("Line 1").assertIsDisplayed()
-        composeRule.onNodeWithText("Error!").assertIsDisplayed()
-        composeRule.onNodeWithText("Info").assertIsDisplayed()
+        composeRule.onNodeWithText("Error!", substring = true).assertIsDisplayed()
+        composeRule.onNodeWithText("Info", substring = true).assertIsDisplayed()
     }
 
     @Test

--- a/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
@@ -60,7 +60,8 @@ class MainActivity : AppCompatActivity() {
         // Compose terminal output UI
         composeOutput.setContent {
             UsbTerminalTheme {
-                val autoScrollEnabled = settingViewModel.currentAutoScroll.collectAsState(initial = true).value
+                val autoScrollEnabled =
+                    settingViewModel.currentAutoScroll.collectAsState(initial = true).value
                 TerminalOutput(
                     logs = viewModel.output,
                     autoScroll = autoScrollEnabled,
@@ -85,8 +86,11 @@ class MainActivity : AppCompatActivity() {
 
         etInput.setOnEditorActionListener { _, actionId, event ->
             if (actionId == EditorInfo.IME_ACTION_SEND ||
-                (event?.keyCode == KeyEvent.KEYCODE_ENTER &&
-                        event.action == KeyEvent.ACTION_DOWN)) {
+                (
+                    event?.keyCode == KeyEvent.KEYCODE_ENTER &&
+                        event.action == KeyEvent.ACTION_DOWN
+                )
+            ) {
                 sendCommand()
                 true
             } else {
@@ -95,34 +99,38 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    override fun onResume() {
-        super.onResume()
+    override fun onStart() {
+        super.onStart()
         viewModel.connectIfAlreadyHasPermission()
     }
 
-    override fun onPause() {
-        super.onPause()
+    override fun onStop() {
+        super.onStop()
         viewModel.disconnect()
     }
 
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean =
+        when (item.itemId) {
             R.id.actionConnect -> {
                 viewModel.connect()
                 true
             }
+
             R.id.actionDisconnect -> {
                 viewModel.disconnect()
                 true
             }
+
             R.id.actionSettings -> {
                 SettingModalBottomSheet(viewModel = settingViewModel)
                     .show(supportFragmentManager, TAG)
                 true
             }
-            else -> false
+
+            else -> {
+                false
+            }
         }
-    }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
         val inflater: MenuInflater = menuInflater

--- a/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
@@ -78,7 +78,7 @@ internal class ArduinoRepository
         override fun disconnect() {
             try {
                 if (::connection.isInitialized) connection.close()
-                _messageFlow.value = context.getString(R.string.helper_info_serial_connection_closed)
+                _infoMessageFlow.value = context.getString(R.string.helper_info_serial_connection_closed)
             } catch (e: UninitializedPropertyAccessException) {
                 _errorMessageFlow.value =
                     context.getString(R.string.helper_error_connection_not_ready_to_close)

--- a/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
@@ -9,8 +9,12 @@ import com.felhr.usbserial.UsbSerialDevice
 import com.felhr.usbserial.UsbSerialInterface
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.kabiri.android.usbterminal.R
@@ -49,19 +53,31 @@ internal class ArduinoRepository
     ) : IArduinoRepository {
         private var currentBaudRate = DEFAULT_BAUD_RATE // Default value
 
-        private val _messageFlow = MutableStateFlow("")
+        private val _messageFlow =
+            MutableSharedFlow<String>(
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
         override val messageFlow: Flow<String>
             get() =
                 _messageFlow
                     .combine(arduinoSerialReceiver.liveOutput) { a, b -> a + b }
 
-        private val _infoMessageFlow = MutableStateFlow("")
+        private val _infoMessageFlow =
+            MutableSharedFlow<String>(
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
         override val infoMessageFlow: Flow<String>
             get() =
                 _infoMessageFlow
                     .combine(arduinoSerialReceiver.liveInfoOutput) { a, b -> a + b }
 
-        private val _errorMessageFlow = MutableStateFlow("")
+        private val _errorMessageFlow =
+            MutableSharedFlow<String>(
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
         override val errorMessageFlow: Flow<String>
             get() =
                 _errorMessageFlow
@@ -78,7 +94,8 @@ internal class ArduinoRepository
         override fun disconnect() {
             try {
                 if (::connection.isInitialized) connection.close()
-                _infoMessageFlow.value = context.getString(R.string.helper_info_serial_connection_closed)
+                _infoMessageFlow.value =
+                    context.getString(R.string.helper_info_serial_connection_closed)
             } catch (e: UninitializedPropertyAccessException) {
                 _errorMessageFlow.value =
                     context.getString(R.string.helper_error_connection_not_ready_to_close)
@@ -208,4 +225,10 @@ internal class ArduinoRepository
                     " \n${e.localizedMessage}"
             }
         }
+    }
+
+private var kotlinx.coroutines.flow.MutableSharedFlow<String>.value: String
+    get() = ""
+    set(v) {
+        tryEmit(v)
     }

--- a/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/data/repository/ArduinoRepository.kt
@@ -12,9 +12,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import org.kabiri.android.usbterminal.R
@@ -55,7 +52,7 @@ internal class ArduinoRepository
 
         private val _messageFlow =
             MutableSharedFlow<String>(
-                extraBufferCapacity = 1,
+                replay = 1,
                 onBufferOverflow = BufferOverflow.DROP_OLDEST,
             )
         override val messageFlow: Flow<String>
@@ -65,7 +62,7 @@ internal class ArduinoRepository
 
         private val _infoMessageFlow =
             MutableSharedFlow<String>(
-                extraBufferCapacity = 1,
+                replay = 1,
                 onBufferOverflow = BufferOverflow.DROP_OLDEST,
             )
         override val infoMessageFlow: Flow<String>
@@ -75,7 +72,7 @@ internal class ArduinoRepository
 
         private val _errorMessageFlow =
             MutableSharedFlow<String>(
-                extraBufferCapacity = 1,
+                replay = 1,
                 onBufferOverflow = BufferOverflow.DROP_OLDEST,
             )
         override val errorMessageFlow: Flow<String>
@@ -94,7 +91,7 @@ internal class ArduinoRepository
         override fun disconnect() {
             try {
                 if (::connection.isInitialized) connection.close()
-                _infoMessageFlow.value =
+                _messageFlow.value =
                     context.getString(R.string.helper_info_serial_connection_closed)
             } catch (e: UninitializedPropertyAccessException) {
                 _errorMessageFlow.value =
@@ -227,7 +224,7 @@ internal class ArduinoRepository
         }
     }
 
-private var kotlinx.coroutines.flow.MutableSharedFlow<String>.value: String
+private var MutableSharedFlow<String>.value: String
     get() = ""
     set(v) {
         tryEmit(v)

--- a/app/src/main/java/org/kabiri/android/usbterminal/data/repository/UsbRepository.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/data/repository/UsbRepository.kt
@@ -21,108 +21,127 @@ import javax.inject.Inject
 internal interface IUsbRepository {
     val usbDevice: SharedFlow<UsbDevice?>
     val infoMessageFlow: Flow<String>
+
     fun scanForArduinoDevices(): List<UsbDevice>
+
     fun requestUsbPermission(device: UsbDevice)
+
     fun hasPermission(device: UsbDevice): Boolean
-    fun onPermissionResult(device: UsbDevice?, granted: Boolean)
+
+    fun onPermissionResult(
+        device: UsbDevice?,
+        granted: Boolean,
+    )
+
     fun onDeviceAttached(device: UsbDevice?)
+
     fun onDeviceDetached(device: UsbDevice?)
+
     fun onUnknownAction(intent: Intent?)
+
     fun disconnect()
 }
 
 internal class UsbRepository
-@Inject constructor(
-    private val context: Context,
-    private val scope: CoroutineScope,
-): IUsbRepository {
+    @Inject
+    constructor(
+        private val context: Context,
+        private val scope: CoroutineScope,
+    ) : IUsbRepository {
+        private val _usbDevice = MutableSharedFlow<UsbDevice?>(replay = 1)
+        override val usbDevice: SharedFlow<UsbDevice?> = _usbDevice.asSharedFlow()
 
-    private val _usbDevice = MutableSharedFlow<UsbDevice?>(replay = 1)
-    override val usbDevice: SharedFlow<UsbDevice?> = _usbDevice.asSharedFlow()
+        private val _infoMessageFlow = MutableStateFlow<String>("")
+        override val infoMessageFlow: SharedFlow<String> = _infoMessageFlow.asSharedFlow()
 
-    private val _infoMessageFlow = MutableStateFlow<String>("")
-    override val infoMessageFlow: SharedFlow<String> = _infoMessageFlow.asSharedFlow()
-
-    override fun scanForArduinoDevices(): List<UsbDevice> {
-        val usbManager = context.getSystemService(UsbManager::class.java)
-        val deviceList = usbManager.deviceList
-        return deviceList.values.toList()
-    }
-
-    override fun requestUsbPermission(device: UsbDevice) {
-        val intent = Intent(Constants.ACTION_USB_PERMISSION)
-        val permissionIntent = PendingIntent.getBroadcast(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-        ContextCompat.registerReceiver(
-            context,
-            UsbPermissionReceiver(this@UsbRepository),
-            IntentFilter(Constants.ACTION_USB_PERMISSION),
-            ContextCompat.RECEIVER_EXPORTED
-        )
-        scope.launch {
-            _usbDevice.emit(device)
+        override fun scanForArduinoDevices(): List<UsbDevice> {
             val usbManager = context.getSystemService(UsbManager::class.java)
-            usbManager.requestPermission(device, permissionIntent)
+            val deviceList = usbManager.deviceList
+            return deviceList.values.toList()
         }
-    }
 
-    override fun hasPermission(device: UsbDevice): Boolean {
-        val usbManager = context.getSystemService(UsbManager::class.java)
-        return usbManager.hasPermission(device)
-    }
+        override fun requestUsbPermission(device: UsbDevice) {
+            val intent =
+                Intent(Constants.ACTION_USB_PERMISSION).apply {
+                    setPackage(context.packageName)
+                }
+            val permissionIntent =
+                PendingIntent.getBroadcast(
+                    context,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+                )
+            ContextCompat.registerReceiver(
+                context,
+                UsbPermissionReceiver(this@UsbRepository),
+                IntentFilter(Constants.ACTION_USB_PERMISSION),
+                ContextCompat.RECEIVER_EXPORTED,
+            )
+            scope.launch {
+                val usbManager = context.getSystemService(UsbManager::class.java)
+                if (usbManager.hasPermission(device)) {
+                    _usbDevice.emit(device)
+                } else {
+                    usbManager.requestPermission(device, permissionIntent)
+                }
+            }
+        }
 
-    override fun onPermissionResult(
-        device: UsbDevice?,
-        granted: Boolean
-    ) {
-        val deviceInfo =
-            "${device?.manufacturerName} " +
+        override fun hasPermission(device: UsbDevice): Boolean {
+            val usbManager = context.getSystemService(UsbManager::class.java)
+            return usbManager.hasPermission(device)
+        }
+
+        override fun onPermissionResult(
+            device: UsbDevice?,
+            granted: Boolean,
+        ) {
+            val deviceInfo =
+                "${device?.manufacturerName} " +
                     "${device?.productName} " +
                     "${device?.vendorId} " +
                     "${device?.productId}"
-        scope.launch {
-            if (granted) {
-                val infoMsg =
-                    "${context.getString(R.string.breceiver_info_usb_permission_granted)} " +
+            scope.launch {
+                if (granted) {
+                    val infoMsg =
+                        "${context.getString(R.string.breceiver_info_usb_permission_granted)} " +
                             deviceInfo
-                _infoMessageFlow.emit("\n$infoMsg")
-            } else {
-                val errorMsg =
-                    "${context.getString(R.string.breceiver_error_usb_permission_denied)} " +
-                        deviceInfo
-                _infoMessageFlow.emit(errorMsg)
+                    _infoMessageFlow.emit("\n$infoMsg")
+                    device?.let { _usbDevice.emit(it) }
+                } else {
+                    val errorMsg =
+                        "${context.getString(R.string.breceiver_error_usb_permission_denied)} " +
+                            deviceInfo
+                    _infoMessageFlow.emit(errorMsg)
+                }
+            }
+        }
+
+        override fun onDeviceAttached(device: UsbDevice?) {
+            scope.launch {
+                val attachedMsg = context.getString(R.string.breceiver_info_device_attached)
+                _infoMessageFlow.emit(attachedMsg)
+            }
+        }
+
+        override fun onDeviceDetached(device: UsbDevice?) {
+            scope.launch {
+                val detachedMsg = context.getString(R.string.breceiver_info_device_detached)
+                _infoMessageFlow.emit(detachedMsg)
+            }
+        }
+
+        override fun onUnknownAction(intent: Intent?) {
+            scope.launch {
+                val unknownActionMsg = context.getString(R.string.breceiver_info_unknown_intent_action)
+                _infoMessageFlow.emit(unknownActionMsg)
+            }
+        }
+
+        override fun disconnect() {
+            scope.launch {
+                _usbDevice.emit(null)
             }
         }
     }
-
-    override fun onDeviceAttached(device: UsbDevice?) {
-        scope.launch {
-            val attachedMsg = context.getString(R.string.breceiver_info_device_attached)
-            _infoMessageFlow.emit(attachedMsg)
-        }
-    }
-
-    override fun onDeviceDetached(device: UsbDevice?) {
-        scope.launch {
-            val detachedMsg = context.getString(R.string.breceiver_info_device_detached)
-            _infoMessageFlow.emit(detachedMsg)
-        }
-    }
-
-    override fun onUnknownAction(intent: Intent?) {
-        scope.launch {
-            val unknownActionMsg = context.getString(R.string.breceiver_info_unknown_intent_action)
-            _infoMessageFlow.emit(unknownActionMsg)
-        }
-    }
-
-    override fun disconnect() {
-        scope.launch {
-            _usbDevice.emit(null)
-        }
-    }
-}

--- a/app/src/main/java/org/kabiri/android/usbterminal/data/repository/UsbRepository.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/data/repository/UsbRepository.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
@@ -54,7 +53,7 @@ internal class UsbRepository
 
         private val _infoMessageFlow =
             MutableSharedFlow<String>(
-                extraBufferCapacity = 1,
+                replay = 1,
                 onBufferOverflow = BufferOverflow.DROP_OLDEST,
             )
         override val infoMessageFlow: SharedFlow<String> = _infoMessageFlow.asSharedFlow()
@@ -149,10 +148,4 @@ internal class UsbRepository
                 _usbDevice.emit(null)
             }
         }
-    }
-
-private var kotlinx.coroutines.flow.MutableSharedFlow<String>.value: String
-    get() = ""
-    set(v) {
-        tryEmit(v)
     }

--- a/app/src/main/java/org/kabiri/android/usbterminal/data/repository/UsbRepository.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/data/repository/UsbRepository.kt
@@ -8,6 +8,7 @@ import android.hardware.usb.UsbDevice
 import android.hardware.usb.UsbManager
 import androidx.core.content.ContextCompat
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -51,7 +52,11 @@ internal class UsbRepository
         private val _usbDevice = MutableSharedFlow<UsbDevice?>(replay = 1)
         override val usbDevice: SharedFlow<UsbDevice?> = _usbDevice.asSharedFlow()
 
-        private val _infoMessageFlow = MutableStateFlow<String>("")
+        private val _infoMessageFlow =
+            MutableSharedFlow<String>(
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
         override val infoMessageFlow: SharedFlow<String> = _infoMessageFlow.asSharedFlow()
 
         override fun scanForArduinoDevices(): List<UsbDevice> {
@@ -144,4 +149,10 @@ internal class UsbRepository
                 _usbDevice.emit(null)
             }
         }
+    }
+
+private var kotlinx.coroutines.flow.MutableSharedFlow<String>.value: String
+    get() = ""
+    set(v) {
+        tryEmit(v)
     }

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -18,6 +18,15 @@ import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import org.kabiri.android.usbterminal.R
@@ -60,19 +69,47 @@ internal fun TerminalOutput(
         verticalArrangement = Arrangement.Bottom,
     ) {
         itemsIndexed(logs, key = { index, _ -> index }) { _, item ->
-            val color =
-                when (item.type) {
-                    OutputText.OutputType.TYPE_ERROR -> MaterialTheme.colorScheme.error
-                    OutputText.OutputType.TYPE_INFO -> MaterialTheme.colorScheme.onBackground
-                    else -> MaterialTheme.colorScheme.onBackground
-                }
-            Text(
-                text = item.text,
-                color = color,
-                style = MaterialTheme.typography.bodyMedium,
-                maxLines = Int.MAX_VALUE,
-                overflow = TextOverflow.Clip,
-            )
+            val isNormal = item.type == OutputText.OutputType.TYPE_NORMAL
+            val isInfo = item.type == OutputText.OutputType.TYPE_INFO
+            val isError = item.type == OutputText.OutputType.TYPE_ERROR
+
+            val backgroundColor = when {
+                isError -> MaterialTheme.colorScheme.error.copy(alpha = 0.15f)
+                isInfo -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.15f)
+                else -> Color.Transparent
+            }
+
+            val textColor = when {
+                isError -> MaterialTheme.colorScheme.error
+                isInfo -> MaterialTheme.colorScheme.onBackground
+                else -> MaterialTheme.colorScheme.onBackground
+            }
+
+            val prefix = when {
+                isError -> "⚠️ "
+                isInfo -> "ℹ️ "
+                else -> ""
+            }
+
+            val fontFamily = if (isNormal) FontFamily.Monospace else FontFamily.Default
+            val fontStyle = if (isInfo) FontStyle.Italic else FontStyle.Normal
+
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(backgroundColor)
+                    .padding(horizontal = 12.dp, vertical = if (isNormal) 2.dp else 6.dp)
+            ) {
+                Text(
+                    text = prefix + item.text,
+                    color = textColor,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontFamily = fontFamily,
+                    fontStyle = fontStyle,
+                    maxLines = Int.MAX_VALUE,
+                    overflow = TextOverflow.Clip,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -1,12 +1,19 @@
 package org.kabiri.android.usbterminal.ui.terminal
 
 import android.widget.Toast
+import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Divider
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -14,17 +21,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
@@ -68,37 +70,41 @@ internal fun TerminalOutput(
         contentPadding = PaddingValues(vertical = 8.dp),
         verticalArrangement = Arrangement.Bottom,
     ) {
-        itemsIndexed(logs, key = { index, _ -> index }) { _, item ->
+        itemsIndexed(logs, key = { index, _ -> index }) { index, item ->
             val isNormal = item.type == OutputText.OutputType.TYPE_NORMAL
             val isInfo = item.type == OutputText.OutputType.TYPE_INFO
             val isError = item.type == OutputText.OutputType.TYPE_ERROR
 
-            val backgroundColor = when {
-                isError -> MaterialTheme.colorScheme.error.copy(alpha = 0.15f)
-                isInfo -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.15f)
-                else -> Color.Transparent
-            }
+            val backgroundColor =
+                when {
+                    isError -> MaterialTheme.colorScheme.error.copy(alpha = 0.15f)
+                    isInfo -> MaterialTheme.colorScheme.secondary.copy(alpha = 0.15f)
+                    else -> Color.Transparent
+                }
 
-            val textColor = when {
-                isError -> MaterialTheme.colorScheme.error
-                isInfo -> MaterialTheme.colorScheme.onBackground
-                else -> MaterialTheme.colorScheme.onBackground
-            }
+            val textColor =
+                when {
+                    isError -> MaterialTheme.colorScheme.error
+                    isInfo -> MaterialTheme.colorScheme.onBackground
+                    else -> MaterialTheme.colorScheme.onBackground
+                }
 
-            val prefix = when {
-                isError -> "⚠️ "
-                isInfo -> "ℹ️ "
-                else -> ""
-            }
+            val prefix =
+                when {
+                    isError -> "⚠️ "
+                    isInfo -> "ℹ️ "
+                    else -> ""
+                }
 
             val fontFamily = if (isNormal) FontFamily.Monospace else FontFamily.Default
             val fontStyle = if (isInfo) FontStyle.Italic else FontStyle.Normal
 
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(backgroundColor)
-                    .padding(horizontal = 12.dp, vertical = if (isNormal) 2.dp else 6.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .background(backgroundColor)
+                        .padding(horizontal = 12.dp, vertical = if (isNormal) 2.dp else 6.dp),
             ) {
                 Text(
                     text = prefix + item.text,
@@ -108,6 +114,12 @@ internal fun TerminalOutput(
                     fontStyle = fontStyle,
                     maxLines = Int.MAX_VALUE,
                     overflow = TextOverflow.Clip,
+                )
+            }
+            if (index < logs.lastIndex) {
+                HorizontalDivider(
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.05f),
+                    thickness = 1.dp,
                 )
             }
         }

--- a/app/src/main/java/org/kabiri/android/usbterminal/utils/FlowExtensions.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/utils/FlowExtensions.kt
@@ -1,0 +1,10 @@
+package org.kabiri.android.usbterminal.utils
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+
+internal var SharedFlow<String>.value: String
+    get() = this.replayCache.lastOrNull() ?: ""
+    set(v) {
+        (this as MutableSharedFlow<String>).tryEmit(v)
+    }

--- a/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
@@ -8,9 +8,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
@@ -28,6 +26,7 @@ import org.kabiri.android.usbterminal.util.IResourceProvider
 import org.kabiri.android.usbterminal.util.getArduinoType
 import org.kabiri.android.usbterminal.util.isCloneArduinoBoard
 import org.kabiri.android.usbterminal.util.isOfficialArduinoBoard
+import org.kabiri.android.usbterminal.utils.value
 import javax.inject.Inject
 
 /**
@@ -44,7 +43,7 @@ internal class MainActivityViewModel
     ) : ViewModel() {
         private val _infoMessageFlow =
             MutableSharedFlow<String>(
-                extraBufferCapacity = 1,
+                replay = 1,
                 onBufferOverflow = BufferOverflow.DROP_OLDEST,
             )
         val infoMessage: SharedFlow<String>
@@ -52,7 +51,7 @@ internal class MainActivityViewModel
 
         private val _errorMessageFlow =
             MutableSharedFlow<String>(
-                extraBufferCapacity = 1,
+                replay = 1,
                 onBufferOverflow = BufferOverflow.DROP_OLDEST,
             )
         val errorMessage: SharedFlow<String>
@@ -185,8 +184,8 @@ internal class MainActivityViewModel
         }
     }
 
-private var kotlinx.coroutines.flow.MutableSharedFlow<String>.value: String
-    get() = ""
+internal var SharedFlow<String>.value: String
+    get() = this.replayCache.lastOrNull() ?: ""
     set(v) {
-        tryEmit(v)
+        (this as MutableSharedFlow<String>).tryEmit(v)
     }

--- a/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModel.kt
@@ -5,9 +5,13 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.launchIn
@@ -38,13 +42,21 @@ internal class MainActivityViewModel
         private val usbUseCase: IUsbUseCase,
         private val resourceProvider: IResourceProvider,
     ) : ViewModel() {
-        private val _infoMessageFlow = MutableStateFlow("")
-        val infoMessage: StateFlow<String>
-            get() = _infoMessageFlow
+        private val _infoMessageFlow =
+            MutableSharedFlow<String>(
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
+        val infoMessage: SharedFlow<String>
+            get() = _infoMessageFlow.asSharedFlow()
 
-        private val _errorMessageFlow = MutableStateFlow("")
-        val errorMessage: StateFlow<String>
-            get() = _errorMessageFlow
+        private val _errorMessageFlow =
+            MutableSharedFlow<String>(
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST,
+            )
+        val errorMessage: SharedFlow<String>
+            get() = _errorMessageFlow.asSharedFlow()
 
         val output = SnapshotStateList<OutputText>()
 
@@ -171,4 +183,10 @@ internal class MainActivityViewModel
             ).onEach { addOutput(it) }
                 .launchIn(viewModelScope)
         }
+    }
+
+private var kotlinx.coroutines.flow.MutableSharedFlow<String>.value: String
+    get() = ""
+    set(v) {
+        tryEmit(v)
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -32,8 +32,6 @@
         android:id="@+id/composeOutput"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
         app:layout_constraintBottom_toTopOf="@id/etInput"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"

--- a/app/src/test/java/org/kabiri/android/usbterminal/data/repository/UsbRepositoryTest.kt
+++ b/app/src/test/java/org/kabiri/android/usbterminal/data/repository/UsbRepositoryTest.kt
@@ -26,11 +26,9 @@ import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
-import org.kabiri.android.usbterminal.Constants
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class UsbRepositoryTest {
-
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
     private val testScope = TestScope(testDispatcher)
 
@@ -45,16 +43,29 @@ internal class UsbRepositoryTest {
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
 
-        every { mockUsbManager.deviceList } returns hashMapOf(
-            "device1" to mockUsbDevice1,
-            "device2" to mockUsbDevice2,
-        )
+        every { mockUsbManager.deviceList } returns
+            hashMapOf(
+                "device1" to mockUsbDevice1,
+                "device2" to mockUsbDevice2,
+            )
         every { mockContext.getSystemService(UsbManager::class.java) } returns mockUsbManager
+        every { mockContext.packageName } returns "org.kabiri.android.usbterminal"
+        every { mockUsbManager.hasPermission(any<UsbDevice>()) } returns false
+        every { mockUsbDevice1.manufacturerName } returns "Manufacturer1"
+        every { mockUsbDevice1.productName } returns "Product1"
+        every { mockUsbDevice1.vendorId } returns 1
+        every { mockUsbDevice1.productId } returns 1
 
-        sut = UsbRepository(
-            context = mockContext,
-            scope = testScope,
-        )
+        every { mockUsbDevice2.manufacturerName } returns "Manufacturer2"
+        every { mockUsbDevice2.productName } returns "Product2"
+        every { mockUsbDevice2.vendorId } returns 2
+        every { mockUsbDevice2.productId } returns 2
+
+        sut =
+            UsbRepository(
+                context = mockContext,
+                scope = testScope,
+            )
     }
 
     @After
@@ -64,203 +75,213 @@ internal class UsbRepositoryTest {
     }
 
     @Test
-    fun `scanForArduinoDevices returns list of usb devices from usbManager`() = runTest {
-        // arrange
-        val expectedDeviceList = listOf(mockUsbDevice1, mockUsbDevice2)
+    fun `scanForArduinoDevices returns list of usb devices from usbManager`() =
+        runTest {
+            // arrange
+            val expectedDeviceList = listOf(mockUsbDevice1, mockUsbDevice2)
 
-        // act
-        val actualDeviceList = sut.scanForArduinoDevices()
-        advanceUntilIdle()
+            // act
+            val actualDeviceList = sut.scanForArduinoDevices()
+            advanceUntilIdle()
 
-        // assert
-        verify { mockUsbManager.deviceList }
-        assertThat(actualDeviceList).isNotEmpty()
-        assertThat(actualDeviceList).hasSize(actualDeviceList.size)
-        assertThat(actualDeviceList.containsAll(expectedDeviceList)).isTrue()
-    }
-
-    @Test
-    fun `requestUsbPermission registers receiver and requests permission`() = runTest {
-        // arrange
-        mockkStatic(PendingIntent::class)
-        mockkStatic(ContextCompat::class)
-        val mockIntent: PendingIntent = mockk()
-        every {
-            PendingIntent.getBroadcast(
-                mockContext,
-                0,
-                any(),
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-        } returns mockIntent
-        every {
-            ContextCompat.registerReceiver(
-                mockContext,
-                any<UsbPermissionReceiver>(),
-                IntentFilter(Constants.ACTION_USB_PERMISSION),
-                ContextCompat.RECEIVER_EXPORTED
-            )
-        } returns null
-
-        // act
-        sut.requestUsbPermission(mockUsbDevice1)
-        advanceUntilIdle()
-
-        // assert
-        assertThat(sut.usbDevice.first()).isEqualTo(mockUsbDevice1)
-        verify {
-            PendingIntent.getBroadcast(
-                mockContext,
-                0,
-                any<Intent>(),
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
-            ContextCompat.registerReceiver(
-                mockContext,
-                any<UsbPermissionReceiver>(),
-                any<IntentFilter>(),
-                ContextCompat.RECEIVER_EXPORTED
-            )
-            mockUsbManager.requestPermission(mockUsbDevice1, mockIntent)
+            // assert
+            verify { mockUsbManager.deviceList }
+            assertThat(actualDeviceList).isNotEmpty()
+            assertThat(actualDeviceList).hasSize(actualDeviceList.size)
+            assertThat(actualDeviceList.containsAll(expectedDeviceList)).isTrue()
         }
-    }
 
     @Test
-    fun `hasPermission returns true when granted`() = runTest {
-        // arrange
-        every { mockUsbManager.hasPermission(mockUsbDevice1) } returns true
+    fun `requestUsbPermission registers receiver and requests permission`() =
+        runTest {
+            // arrange
+            mockkStatic(PendingIntent::class)
+            mockkStatic(ContextCompat::class)
+            val mockIntent: PendingIntent = mockk()
+            every {
+                PendingIntent.getBroadcast(
+                    mockContext,
+                    0,
+                    any(),
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+                )
+            } returns mockIntent
+            every {
+                ContextCompat.registerReceiver(
+                    mockContext,
+                    any<UsbPermissionReceiver>(),
+                    any<IntentFilter>(),
+                    ContextCompat.RECEIVER_EXPORTED,
+                )
+            } returns null
 
-        // act
-        val actual = sut.hasPermission(mockUsbDevice1)
+            // act
+            sut.requestUsbPermission(mockUsbDevice1)
+            advanceUntilIdle()
 
-        // assert
-        assertThat(actual).isTrue()
-        verify { mockUsbManager.hasPermission(mockUsbDevice1) }
-    }
-
-    @Test
-    fun `hasPermission returns false when denied`() = runTest {
-        // arrange
-        every { mockUsbManager.hasPermission(mockUsbDevice2) } returns false
-
-        // act
-        val actual = sut.hasPermission(mockUsbDevice2)
-
-        // assert
-        assertThat(actual).isFalse()
-        verify { mockUsbManager.hasPermission(mockUsbDevice2) }
-    }
-
-    @Test
-    fun `onPermissionResult emits info when granted`() = runTest(testDispatcher) {
-        // arrange
-        val fakeGranted = true
-        val fakeId = 123
-        val fakeString = "doesn't matter"
-        val fakeMsg = "permission granted"
-        val fakeDeviceInfo = "$fakeString $fakeString $fakeId $fakeId"
-        val expected = "\n$fakeMsg $fakeDeviceInfo"
-        every { mockContext.getString(any()) } returns fakeMsg
-        every { mockUsbDevice1.manufacturerName } returns fakeString
-        every { mockUsbDevice1.productName } returns fakeString
-        every { mockUsbDevice1.vendorId } returns fakeId
-        every { mockUsbDevice1.productId } returns fakeId
-
-        // act
-        sut.onPermissionResult(
-            device = mockUsbDevice1,
-            granted = fakeGranted
-        )
-        advanceUntilIdle()
-
-        // assert
-        assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
-    }
+            // assert
+            verify {
+                PendingIntent.getBroadcast(
+                    mockContext,
+                    0,
+                    any<Intent>(),
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+                )
+                ContextCompat.registerReceiver(
+                    mockContext,
+                    any<UsbPermissionReceiver>(),
+                    any<IntentFilter>(),
+                    ContextCompat.RECEIVER_EXPORTED,
+                )
+                mockUsbManager.requestPermission(mockUsbDevice1, mockIntent)
+            }
+        }
 
     @Test
-    fun `onPermissionResult emits info when denied`() = runTest(testDispatcher) {
-        // arrange
-        val fakeGranted = false
-        val fakeId = 123
-        val fakeString = "doesn't matter"
-        val fakeMsg = "permission denied"
-        val fakeDeviceInfo = "$fakeString $fakeString $fakeId $fakeId"
-        val expected = "$fakeMsg $fakeDeviceInfo"
-        every { mockContext.getString(any()) } returns fakeMsg
-        every { mockUsbDevice1.manufacturerName } returns fakeString
-        every { mockUsbDevice1.productName } returns fakeString
-        every { mockUsbDevice1.vendorId } returns fakeId
-        every { mockUsbDevice1.productId } returns fakeId
+    fun `hasPermission returns true when granted`() =
+        runTest {
+            // arrange
+            every { mockUsbManager.hasPermission(mockUsbDevice1) } returns true
 
-        // act
-        sut.onPermissionResult(
-            device = mockUsbDevice1,
-            granted = fakeGranted
-        )
-        advanceUntilIdle()
+            // act
+            val actual = sut.hasPermission(mockUsbDevice1)
 
-        // assert
-        assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
-    }
+            // assert
+            assertThat(actual).isTrue()
+            verify { mockUsbManager.hasPermission(mockUsbDevice1) }
+        }
 
     @Test
-    fun `onDeviceAttached emits info when granted`() = runTest(testDispatcher) {
-        // arrange
-        val expected = "fake device attached"
-        every { mockContext.getString(any()) } returns expected
+    fun `hasPermission returns false when denied`() =
+        runTest {
+            // arrange
+            every { mockUsbManager.hasPermission(mockUsbDevice2) } returns false
 
-        // act
-        sut.onDeviceAttached(device = mockUsbDevice1)
-        advanceUntilIdle()
+            // act
+            val actual = sut.hasPermission(mockUsbDevice2)
 
-        // assert
-        assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
-    }
-
-    @Test
-    fun `onDeviceDetached emits info when granted`() = runTest(testDispatcher) {
-        // arrange
-        val expected = "fake device detached"
-        every { mockContext.getString(any()) } returns expected
-
-        // act
-        sut.onDeviceDetached(device = mockUsbDevice1)
-        advanceUntilIdle()
-
-        // assert
-        assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
-    }
+            // assert
+            assertThat(actual).isFalse()
+            verify { mockUsbManager.hasPermission(mockUsbDevice2) }
+        }
 
     @Test
-    fun `onUnknownAction emits info when granted`() = runTest(testDispatcher) {
-        // arrange
-        val expected = "strange action received"
-        val mockIntent: Intent = mockk()
-        every { mockContext.getString(any()) } returns expected
+    fun `onPermissionResult emits info when granted`() =
+        runTest(testDispatcher) {
+            // arrange
+            val fakeGranted = true
+            val fakeId = 123
+            val fakeString = "doesn't matter"
+            val fakeMsg = "permission granted"
+            val fakeDeviceInfo = "$fakeString $fakeString $fakeId $fakeId"
+            val expected = "\n$fakeMsg $fakeDeviceInfo"
+            every { mockContext.getString(any()) } returns fakeMsg
+            every { mockUsbDevice1.manufacturerName } returns fakeString
+            every { mockUsbDevice1.productName } returns fakeString
+            every { mockUsbDevice1.vendorId } returns fakeId
+            every { mockUsbDevice1.productId } returns fakeId
 
-        // act
-        sut.onUnknownAction(mockIntent)
-        advanceUntilIdle()
+            // act
+            sut.onPermissionResult(
+                device = mockUsbDevice1,
+                granted = fakeGranted,
+            )
+            advanceUntilIdle()
 
-        // assert
-        assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
-    }
+            // assert
+            assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
+        }
 
     @Test
-    fun `onDisconnect clears usbDevice`() = runTest {
-        // arrange
-        mockkStatic(PendingIntent::class)
-        mockkStatic(ContextCompat::class)
-        every { PendingIntent.getBroadcast(any(), any(), any(), any()) } returns mockk()
-        sut.requestUsbPermission(mockUsbDevice1)
-        advanceUntilIdle()
-        assertThat(sut.usbDevice.first()).isNotNull()
+    fun `onPermissionResult emits info when denied`() =
+        runTest(testDispatcher) {
+            // arrange
+            val fakeGranted = false
+            val fakeId = 123
+            val fakeString = "doesn't matter"
+            val fakeMsg = "permission denied"
+            val fakeDeviceInfo = "$fakeString $fakeString $fakeId $fakeId"
+            val expected = "$fakeMsg $fakeDeviceInfo"
+            every { mockContext.getString(any()) } returns fakeMsg
+            every { mockUsbDevice1.manufacturerName } returns fakeString
+            every { mockUsbDevice1.productName } returns fakeString
+            every { mockUsbDevice1.vendorId } returns fakeId
+            every { mockUsbDevice1.productId } returns fakeId
 
-        // act
-        sut.disconnect()
-        advanceUntilIdle()
+            // act
+            sut.onPermissionResult(
+                device = mockUsbDevice1,
+                granted = fakeGranted,
+            )
+            advanceUntilIdle()
 
-        // assert
-        assertThat(sut.usbDevice.first()).isNull()
-    }
+            // assert
+            assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
+        }
+
+    @Test
+    fun `onDeviceAttached emits info when granted`() =
+        runTest(testDispatcher) {
+            // arrange
+            val expected = "fake device attached"
+            every { mockContext.getString(any()) } returns expected
+
+            // act
+            sut.onDeviceAttached(device = mockUsbDevice1)
+            advanceUntilIdle()
+
+            // assert
+            assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
+        }
+
+    @Test
+    fun `onDeviceDetached emits info when granted`() =
+        runTest(testDispatcher) {
+            // arrange
+            val expected = "fake device detached"
+            every { mockContext.getString(any()) } returns expected
+
+            // act
+            sut.onDeviceDetached(device = mockUsbDevice1)
+            advanceUntilIdle()
+
+            // assert
+            assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
+        }
+
+    @Test
+    fun `onUnknownAction emits info when granted`() =
+        runTest(testDispatcher) {
+            // arrange
+            val expected = "strange action received"
+            val mockIntent: Intent = mockk()
+            every { mockContext.getString(any()) } returns expected
+
+            // act
+            sut.onUnknownAction(mockIntent)
+            advanceUntilIdle()
+
+            // assert
+            assertThat(sut.infoMessageFlow.first()).isEqualTo(expected)
+        }
+
+    @Test
+    fun `onDisconnect clears usbDevice`() =
+        runTest {
+            // arrange
+            mockkStatic(PendingIntent::class)
+            mockkStatic(ContextCompat::class)
+            every { PendingIntent.getBroadcast(any(), any(), any(), any()) } returns mockk()
+            every { ContextCompat.registerReceiver(any(), any(), any(), any()) } returns mockk()
+            sut.onPermissionResult(mockUsbDevice1, true)
+            advanceUntilIdle()
+            assertThat(sut.usbDevice.first()).isNotNull()
+
+            // act
+            sut.disconnect()
+            advanceUntilIdle()
+
+            // assert
+            assertThat(sut.usbDevice.first()).isNull()
+        }
 }

--- a/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
+++ b/app/src/test/java/org/kabiri/android/usbterminal/viewmodel/MainActivityViewModelTest.kt
@@ -90,12 +90,12 @@ internal class MainActivityViewModelTest {
                 )
 
             // act
-            deviceFlow.value = mockDevice
+            deviceFlow.tryEmit(mockDevice)
             advanceUntilIdle()
 
             // assert
             verify(exactly = 1) { mockArduinoUsecase.openDeviceAndPort(mockDevice) }
-            assertThat(sut.infoMessage.value).contains(expected.toString())
+            assertThat(sut.infoMessage.replayCache.lastOrNull() ?: "").contains(expected.toString())
         }
 
     @Test
@@ -115,12 +115,12 @@ internal class MainActivityViewModelTest {
                 )
 
             // act
-            deviceFlow.value = expected
+            deviceFlow.tryEmit(expected)
             advanceUntilIdle()
 
             // assert
             verify(exactly = 0) { mockArduinoUsecase.openDeviceAndPort(any()) }
-            assertThat(sut.infoMessage.value).contains(expected.toString())
+            assertThat(sut.infoMessage.replayCache.lastOrNull() ?: "").contains(expected.toString())
         }
 
     @Test
@@ -135,7 +135,7 @@ internal class MainActivityViewModelTest {
             sut.connect()
 
             // assert
-            assertThat(sut.errorMessage.value).isEqualTo(expected)
+            assertThat(sut.errorMessage.replayCache.lastOrNull() ?: "").isEqualTo(expected)
         }
 
     @Test
@@ -158,8 +158,8 @@ internal class MainActivityViewModelTest {
             sut.connect()
 
             // assert
-            assertThat(sut.errorMessage.value).isEqualTo(expectedError)
-            assertThat(sut.infoMessage.value).isEqualTo(expectedInfo)
+            assertThat(sut.errorMessage.replayCache.lastOrNull() ?: "").isEqualTo(expectedError)
+            assertThat(sut.infoMessage.replayCache.lastOrNull() ?: "").isEqualTo(expectedInfo)
             verify(exactly = 1) { mockUsbUseCase.requestPermission(fakeDevice) }
         }
 
@@ -181,7 +181,7 @@ internal class MainActivityViewModelTest {
             sut.connect()
 
             // assert
-            assertThat(sut.infoMessage.value).isEqualTo(expected)
+            assertThat(sut.infoMessage.replayCache.lastOrNull() ?: "").isEqualTo(expected)
             verify(exactly = 1) { mockUsbUseCase.requestPermission(fakeDevice) }
         }
 
@@ -201,7 +201,7 @@ internal class MainActivityViewModelTest {
 
             // assert
             verify(exactly = 1) { mockUsbUseCase.requestPermission(fakeDevice) }
-            assertThat(sut.errorMessage.value).isEqualTo("")
+            assertThat(sut.errorMessage.replayCache.lastOrNull() ?: "").isEqualTo("")
         }
 
     @Test


### PR DESCRIPTION
- Redesigned the terminal output to indicate different log types with colors.
- Fixed an IllegalArgumentException crash on Android 14+ (API 34) by making the USB Permission PendingIntent explicit to our package and applying `FLAG_MUTABLE`.
- Refactored log pipelines (`MutableStateFlow` -> `MutableSharedFlow`) so that duplicate, consecutive terminal messages are printed correctly instead of being silently swallowed.