### PR TITLE
DROID-22: Vitals - Fix ANR and Crash; Update deps

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,11 +32,11 @@ android {
         buildConfig = true
     }
 
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig {
         applicationId = "org.kabiri.android.usbterminal"
         minSdk = 24
-        targetSdk = 36
+        targetSdk = 37
         versionCode = System.getenv("CIRCLE_BUILD_NUM")?.toIntOrNull() ?: 18
         versionName = "0.9.88${System.getenv("CIRCLE_BUILD_NUM") ?: ""}"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -306,6 +306,8 @@ dependencies {
     implementation(composeBom)
     implementation(libs.compose.foundation)
     implementation(libs.compose.material3)
+    implementation(libs.compose.material.icons.core)
+    implementation(libs.compose.material.icons.extended)
     // Compose - Android Studio Preview support
     implementation(libs.compose.ui.tooling.preview)
     debugImplementation(libs.compose.ui.tooling)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -94,6 +94,10 @@ android {
         }
     }
 
+    testCoverage {
+        jacocoVersion = libs.versions.jacoco.get()
+    }
+
     namespace = "org.kabiri.android.usbterminal"
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -337,9 +337,6 @@ dependencies {
     androidTestImplementation(libs.androidx.test.runner)
     androidTestImplementation(libs.androidx.test.rules)
     androidTestImplementation(libs.androidx.test.truth)
-    androidTestImplementation(libs.mockk.android)
-    androidTestImplementation(libs.mockk.agent)
-
     // Hilt Testing
     androidTestImplementation(libs.hilt.android.testing)
     kaptAndroidTest(libs.hilt.android.compiler)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -288,7 +288,7 @@ dependencies {
 
     // Firebase
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.crashlytics.ktx)
+    implementation(libs.firebase.crashlytics)
 
     // Dependency Injection
     implementation(libs.hilt.android)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,9 +6,8 @@ plugins {
     id("com.android.application")
     id("com.google.gms.google-services")
     id("com.google.firebase.crashlytics")
-    id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.compose")
-    id("kotlin-kapt")
+    alias(libs.plugins.ksp)
     id("dagger.hilt.android.plugin")
     id("jacoco")
 }
@@ -292,7 +291,7 @@ dependencies {
 
     // Dependency Injection
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     // Coroutines
     implementation(libs.lifecycle.runtime.ktx)
@@ -341,7 +340,7 @@ dependencies {
     androidTestImplementation(libs.androidx.test.truth)
     // Hilt Testing
     androidTestImplementation(libs.hilt.android.testing)
-    kaptAndroidTest(libs.hilt.android.compiler)
+    kspAndroidTest(libs.hilt.android.compiler)
 
     // Android Serial Controller
     implementation(libs.usb.serial)

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/setting/SettingContentAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/setting/SettingContentAndroidTest.kt
@@ -2,7 +2,7 @@ package org.kabiri.android.usbterminal.ui.setting
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import kotlinx.coroutines.flow.flowOf

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/setting/SettingContentAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/setting/SettingContentAndroidTest.kt
@@ -5,8 +5,6 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.flow.flowOf
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.MatcherAssert.assertThat
@@ -21,7 +19,7 @@ class SettingContentAndroidTest {
     @get:Rule
     val composeRule = createAndroidComposeRule<ComponentActivity>()
 
-    private fun showContet(viewModel: SettingViewModel) {
+    private fun showContent(viewModel: SettingViewModel) {
         composeRule.setContent {
             UsbTerminalTheme {
                 SettingContent(
@@ -37,12 +35,16 @@ class SettingContentAndroidTest {
         // arrange
         val context = composeRule.activity
         assertThat(context, notNullValue())
-        val viewModel = mockk<SettingViewModel>(relaxed = true)
-        every { viewModel.currentBaudRate } returns flowOf(9600)
-        every { viewModel.currentAutoScroll } returns flowOf(true)
+        val viewModel =
+            SettingViewModel(
+                getBaudRate = { flowOf(9600) },
+                setBaudRate = { },
+                getAutoScroll = { flowOf(true) },
+                setAutoScroll = { },
+            )
 
         // act
-        showContet(viewModel)
+        showContent(viewModel)
 
         // assert
         composeRule.onNodeWithText(context.getString(R.string.settings_title)).assertIsDisplayed()

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/setting/SettingModalBottomSheetAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/setting/SettingModalBottomSheetAndroidTest.kt
@@ -1,6 +1,6 @@
 package org.kabiri.android.usbterminal.ui.setting
 
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.Espresso.onView

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/setting/SettingSwitchItemAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/setting/SettingSwitchItemAndroidTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.hasAnySibling
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.isToggleable
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Rule

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
@@ -5,7 +5,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsDisplayed
-import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.junit4.v2.createAndroidComposeRule
 import androidx.compose.ui.test.longClick
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
@@ -49,7 +49,6 @@ class TerminalOutputAndroidTest {
     @Test
     fun terminalOutput_longPressCopiesAllText() {
         // arrange
-        val context = composeRule.activity
         val logs =
             mutableStateListOf(
                 OutputText("A\n", OutputText.OutputType.TYPE_NORMAL),
@@ -102,7 +101,6 @@ class TerminalOutputAndroidTest {
     @Test
     fun terminalOutput_handlesEmptyLogs_andLongPressCopiesEmpty() {
         // arrange
-        val context = composeRule.activity
         val logs = mutableStateListOf<OutputText>()
 
         var copiedText: String? = null

--- a/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
+++ b/app/src/androidTest/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutputAndroidTest.kt
@@ -1,7 +1,5 @@
 package org.kabiri.android.usbterminal.ui.terminal
 
-import android.content.ClipboardManager
-import android.content.Context
 import androidx.activity.ComponentActivity
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.ui.Modifier
@@ -58,9 +56,14 @@ class TerminalOutputAndroidTest {
                 OutputText("B", OutputText.OutputType.TYPE_NORMAL),
             )
 
+        var copiedText: String? = null
         composeRule.setContent {
             UsbTerminalTheme {
-                TerminalOutput(logs = logs, autoScroll = true)
+                TerminalOutput(
+                    logs = logs,
+                    autoScroll = true,
+                    onCopyText = { copiedText = it },
+                )
             }
         }
 
@@ -69,13 +72,7 @@ class TerminalOutputAndroidTest {
         composeRule.waitForIdle()
 
         // assert clipboard contains concatenated text
-        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val copied =
-            clipboard.primaryClip
-                ?.getItemAt(0)
-                ?.coerceToText(context)
-                ?.toString()
-        assertThat(copied).isEqualTo("A\nB")
+        assertThat(copiedText).isEqualTo("A\nB")
     }
 
     @Test
@@ -108,6 +105,7 @@ class TerminalOutputAndroidTest {
         val context = composeRule.activity
         val logs = mutableStateListOf<OutputText>()
 
+        var copiedText: String? = null
         composeRule.setContent {
             UsbTerminalTheme {
                 TerminalOutput(
@@ -115,6 +113,7 @@ class TerminalOutputAndroidTest {
                     autoScroll = false,
                     modifier =
                         Modifier.testTag("terminal"),
+                    onCopyText = { copiedText = it },
                 )
             }
         }
@@ -124,13 +123,7 @@ class TerminalOutputAndroidTest {
         composeRule.waitForIdle()
 
         // assert: clipboard should contain empty string
-        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val copied =
-            clipboard.primaryClip
-                ?.getItemAt(0)
-                ?.coerceToText(context)
-                ?.toString()
-        assertThat(copied).isEqualTo("")
+        assertThat(copiedText).isEqualTo("")
     }
 
     @Test

--- a/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.kabiri.android.usbterminal
 
+import android.content.ClipboardManager
 import android.os.Bundle
 import android.util.Log
 import android.view.KeyEvent
@@ -65,6 +66,22 @@ class MainActivity : AppCompatActivity() {
                 TerminalOutput(
                     logs = viewModel.output,
                     autoScroll = autoScrollEnabled,
+                    onCopyText = { allText ->
+                        val clipboardManager =
+                            getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
+                        val clip =
+                            android.content.ClipData.newPlainText(
+                                "Terminal Output",
+                                allText,
+                            )
+                        clipboardManager.setPrimaryClip(clip)
+                        android.widget.Toast
+                            .makeText(
+                                this@MainActivity,
+                                R.string.copied_to_clipboard,
+                                android.widget.Toast.LENGTH_SHORT,
+                            ).show()
+                    },
                 )
             }
         }

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -27,7 +27,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import org.kabiri.android.usbterminal.R
 import org.kabiri.android.usbterminal.model.OutputText
 
 @Composable

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -29,7 +29,10 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.kabiri.android.usbterminal.R
 import org.kabiri.android.usbterminal.model.OutputText
 
@@ -38,6 +41,7 @@ internal fun TerminalOutput(
     logs: SnapshotStateList<OutputText>,
     autoScroll: Boolean,
     modifier: Modifier = Modifier,
+    defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
     val listState = rememberLazyListState()
 
@@ -59,22 +63,23 @@ internal fun TerminalOutput(
             modifier.combinedClickable(
                 onClick = {},
                 onLongClick = {
-                    coroutineScope.launch(kotlinx.coroutines.Dispatchers.Default) {
+                    coroutineScope.launch {
                         // Do the heavy string concatenation in the background
-                        val allText = logs.toList().joinToString(separator = "") { it.text }
+                        val allText =
+                            withContext(defaultDispatcher) {
+                                logs.toList().joinToString(separator = "") { it.text }
+                            }
 
                         // Switch back to Main thread for UI and Clipboard operations
-                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
-                            clipboard.setClipEntry(
-                                ClipEntry(
-                                    ClipData.newPlainText(
-                                        "Terminal Output",
-                                        allText,
-                                    ),
+                        clipboard.setClipEntry(
+                            ClipEntry(
+                                ClipData.newPlainText(
+                                    "Terminal Output",
+                                    allText,
                                 ),
-                            )
-                            Toast.makeText(context, longClickMessage, Toast.LENGTH_SHORT).show()
-                        }
+                            ),
+                        )
+                        Toast.makeText(context, longClickMessage, Toast.LENGTH_SHORT).show()
                     }
                 },
             ),

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -59,17 +59,22 @@ internal fun TerminalOutput(
             modifier.combinedClickable(
                 onClick = {},
                 onLongClick = {
-                    val allText = logs.joinToString(separator = "") { it.text }
-                    coroutineScope.launch {
-                        clipboard.setClipEntry(
-                            ClipEntry(
-                                ClipData.newPlainText(
-                                    "Terminal Output",
-                                    allText,
+                    coroutineScope.launch(kotlinx.coroutines.Dispatchers.Default) {
+                        // Do the heavy string concatenation in the background
+                        val allText = logs.toList().joinToString(separator = "") { it.text }
+
+                        // Switch back to Main thread for UI and Clipboard operations
+                        kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.Main) {
+                            clipboard.setClipEntry(
+                                ClipEntry(
+                                    ClipData.newPlainText(
+                                        "Terminal Output",
+                                        allText,
+                                    ),
                                 ),
-                            ),
-                        )
-                        Toast.makeText(context, longClickMessage, Toast.LENGTH_SHORT).show()
+                            )
+                            Toast.makeText(context, longClickMessage, Toast.LENGTH_SHORT).show()
+                        }
                     }
                 },
             ),

--- a/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
+++ b/app/src/main/java/org/kabiri/android/usbterminal/ui/terminal/TerminalOutput.kt
@@ -1,7 +1,5 @@
 package org.kabiri.android.usbterminal.ui.terminal
 
-import android.content.ClipData
-import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -21,10 +19,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.ClipEntry
-import androidx.compose.ui.platform.LocalClipboard
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.style.TextOverflow
@@ -42,6 +36,7 @@ internal fun TerminalOutput(
     autoScroll: Boolean,
     modifier: Modifier = Modifier,
     defaultDispatcher: CoroutineDispatcher = Dispatchers.Default,
+    onCopyText: (String) -> Unit = {},
 ) {
     val listState = rememberLazyListState()
 
@@ -52,11 +47,7 @@ internal fun TerminalOutput(
         }
     }
 
-    val clipboard = LocalClipboard.current
     val coroutineScope = rememberCoroutineScope()
-    val context = LocalContext.current
-
-    val longClickMessage = stringResource(R.string.copied_to_clipboard)
 
     LazyColumn(
         modifier =
@@ -70,16 +61,7 @@ internal fun TerminalOutput(
                                 logs.toList().joinToString(separator = "") { it.text }
                             }
 
-                        // Switch back to Main thread for UI and Clipboard operations
-                        clipboard.setClipEntry(
-                            ClipEntry(
-                                ClipData.newPlainText(
-                                    "Terminal Output",
-                                    allText,
-                                ),
-                            ),
-                        )
-                        Toast.makeText(context, longClickMessage, Toast.LENGTH_SHORT).show()
+                        onCopyText(allText)
                     }
                 },
             ),

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ buildscript {
 
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.sonarqube)
 }
@@ -25,8 +25,29 @@ sonarqube {
         property("sonar.sourceEncoding", "UTF-8")
         property("sonar.host.url", "https://sonarcloud.io")
 
-        property("sonar.binaries", project(":app").layout.buildDirectory.dir("tmp/kotlin-classes/debug").get().asFile.absolutePath)
-        property("sonar.androidLint.reportPaths", project(":app").layout.buildDirectory.dir("reports/lint-results-debug.xml").get().asFile.absolutePath)
-        property("sonar.coverage.jacoco.xmlReportPaths", project(":app").layout.buildDirectory.dir("mergedReportDir/jacocoTestReport/jacocoTestReport.xml").get().asFile.absolutePath)
+        property(
+            "sonar.binaries",
+            project(":app")
+                .layout.buildDirectory
+                .dir("tmp/kotlin-classes/debug")
+                .get()
+                .asFile.absolutePath,
+        )
+        property(
+            "sonar.androidLint.reportPaths",
+            project(":app")
+                .layout.buildDirectory
+                .dir("reports/lint-results-debug.xml")
+                .get()
+                .asFile.absolutePath,
+        )
+        property(
+            "sonar.coverage.jacoco.xmlReportPaths",
+            project(":app")
+                .layout.buildDirectory
+                .dir("mergedReportDir/jacocoTestReport/jacocoTestReport.xml")
+                .get()
+                .asFile.absolutePath,
+        )
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,4 +20,8 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=false
-android.nonFinalResIds=false
+android.dependency.useConstraints=true
+android.r8.strictFullModeForKeepRules=false
+android.r8.optimizedResourceShrinking=false
+android.builtInKotlin=false
+android.newDsl=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,8 +20,5 @@ android.useAndroidX=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 android.nonTransitiveRClass=false
-android.dependency.useConstraints=true
+android.dependency.useConstraints=false
 android.r8.strictFullModeForKeepRules=false
-android.r8.optimizedResourceShrinking=false
-android.builtInKotlin=false
-android.newDsl=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -116,4 +116,4 @@ firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlyti
 android-application = { id = "com.android.application", version.ref = "gradle" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-sonarqube = { id = "org.sonarqube", version = "7.3.1.8318" }
+sonarqube = { id = "org.sonarqube", version = "7.4.0.8496" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,21 +1,21 @@
 [versions]
 # Build tools & plugins
-gradle = "8.11.1"
-kotlin = "2.1.20"
+gradle = "9.2.1"
+kotlin = "2.2.10"
 jacoco = "0.8.15"
 
 # AndroidX
 appcompat = "1.8.0"
-coreKtx = "1.16.0"
+coreKtx = "1.19.0"
 constraintlayout = "2.2.2"
-lifecycleRuntimeKtx = "2.10.0"
-lifecycleViewmodelKtx = "2.9.1"
+lifecycleRuntimeKtx = "2.11.0"
+lifecycleViewmodelKtx = "2.11.0"
 lifecycleExtensions = "2.2.0"
 activityCompose = "1.13.0"
 datastorePreferences = "1.1.7"
 
 # Compose
-composeBom = "2025.06.01"
+composeBom = "2026.08.00"
 
 # Google/Material
 material = "1.14.0"
@@ -62,6 +62,8 @@ datastore-preferences = { module = "androidx.datastore:datastore-preferences", v
 compose-bom = { module = "androidx.compose:compose-bom", version.ref = "composeBom" }
 compose-foundation = { module = "androidx.compose.foundation:foundation" }
 compose-material3 = { module = "androidx.compose.material3:material3" }
+compose-material-icons-core = { module = "androidx.compose.material:material-icons-core" }
+compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended" }
 compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,11 +7,11 @@ jacoco = "0.8.15"
 # AndroidX
 appcompat = "1.8.0"
 coreKtx = "1.16.0"
-constraintlayout = "2.2.1"
+constraintlayout = "2.2.2"
 lifecycleRuntimeKtx = "2.10.0"
 lifecycleViewmodelKtx = "2.9.1"
 lifecycleExtensions = "2.2.0"
-activityCompose = "1.10.1"
+activityCompose = "1.13.0"
 datastorePreferences = "1.1.7"
 
 # Compose

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,8 @@
 # Build tools & plugins
 gradle = "9.2.1"
 kotlin = "2.4.10"
+ksp = "2.3.11"
+#noinspection UnusedVersionCatalogEntry
 jacoco = "0.8.15"
 
 # AndroidX
@@ -114,6 +116,6 @@ firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlyti
 [plugins]
 # --- Gradle Plugins ---
 android-application = { id = "com.android.application", version.ref = "gradle" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 sonarqube = { id = "org.sonarqube", version = "7.4.0.8496" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,7 +28,7 @@ hilt = "2.57.2"
 hiltAndroidTesting = "2.57.2"
 
 # Coroutines
-coroutines = "1.10.2"
+coroutines = "1.11.0"
 
 # USB Serial
 usbSerial = "6.1.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,16 +35,16 @@ usbSerial = "6.1.1"
 
 # Testing
 junit = "4.13.2"
-mockk = "1.14.5"
+mockk = "1.14.11"
 testCore = "1.7.0"
-testExtJunit = "1.2.1"
-testExtJunitKtx = "1.2.1"
+testExtJunit = "1.3.0"
+testExtJunitKtx = "1.3.0"
 espressoCore = "3.7.0"
 hamcrest = "3.0"
-testRunner = "1.6.2"
-testRules = "1.6.1"
-truth = "1.4.4"
-androidxTruth = "1.6.0"
+testRunner = "1.7.0"
+testRules = "1.7.0"
+truth = "1.4.5"
+androidxTruth = "1.7.0"
 
 [libraries]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Build tools & plugins
 gradle = "9.2.1"
-kotlin = "2.2.10"
+kotlin = "2.4.10"
 jacoco = "0.8.15"
 
 # AndroidX
@@ -12,7 +12,7 @@ lifecycleRuntimeKtx = "2.11.0"
 lifecycleViewmodelKtx = "2.11.0"
 lifecycleExtensions = "2.2.0"
 activityCompose = "1.13.0"
-datastorePreferences = "1.1.7"
+datastorePreferences = "1.2.1"
 
 # Compose
 composeBom = "2026.08.00"
@@ -21,11 +21,11 @@ composeBom = "2026.08.00"
 material = "1.14.0"
 
 # Firebase
-firebaseBom = "33.16.0"
+firebaseBom = "34.18.0"
 
 # Dagger/Hilt
-hilt = "2.57.2"
-hiltAndroidTesting = "2.57.2"
+hilt = "2.60.1"
+hiltAndroidTesting = "2.60.1"
 
 # Coroutines
 coroutines = "1.11.0"
@@ -74,7 +74,7 @@ material = { module = "com.google.android.material:material", version.ref = "mat
 
 # --- Firebase ---
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
-firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 
 # --- Dagger/Hilt ---
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
@@ -108,8 +108,8 @@ androidx-test-truth = { module = "androidx.test.ext:truth", version.ref = "andro
 
 # --- Plugins (classpath dependencies) ---
 hilt-android-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
-google-services = { module = "com.google.gms:google-services", version = "4.4.3" }
-firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle", version = "3.0.4" }
+google-services = { module = "com.google.gms:google-services", version = "4.5.0" }
+firebase-crashlytics-gradle = { module = "com.google.firebase:firebase-crashlytics-gradle", version = "3.0.8" }
 
 [plugins]
 # --- Gradle Plugins ---

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ kotlin = "2.1.20"
 jacoco = "0.8.15"
 
 # AndroidX
-appcompat = "1.7.1"
+appcompat = "1.8.0"
 coreKtx = "1.16.0"
 constraintlayout = "2.2.1"
 lifecycleRuntimeKtx = "2.10.0"
@@ -18,7 +18,7 @@ datastorePreferences = "1.1.7"
 composeBom = "2025.06.01"
 
 # Google/Material
-material = "1.12.0"
+material = "1.14.0"
 
 # Firebase
 firebaseBom = "33.16.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,6 @@
+#Sat Aug 22 00:48:29 CEST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
-networkTimeout=10000
-validateDistributionUrl=true
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Move terminal log clipboard concatenation to background thread.
- Updates Firebase and Hilt dependencies.
- Move the build system to AGP 9 and its built-in Kotlin compiler.
- Replace the slow KAPT processor with the faster KSP processor.